### PR TITLE
Support context on Option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ script: cargo test
 
 matrix:
   include:
-    - rust: 1.32.0
+    - rust: 1.34.0
       script: cargo check


### PR DESCRIPTION
Adds `.context(...)` and `.with_context(|| ...)` on values of type Option\<T\>.

Fixes #6.