### PR TITLE
Support downcasting errors with context to C *or* E

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -255,7 +255,14 @@ impl Error {
         root_cause
     }
 
-    /// Returns `true` if `E` is the type wrapped by this error object.
+    /// Returns true if `E` is the type held by this error object.
+    ///
+    /// For errors with context, this method returns true if `E` matches the
+    /// type of the context `C` **or** the type of the error on which the
+    /// context has been attached. For details about the interaction between
+    /// context and downcasting, [see here].
+    ///
+    /// [see here]: trait.Context.html#effect-on-downcasting
     pub fn is<E>(&self) -> bool
     where
         E: Display + Debug + Send + Sync + 'static,

--- a/tests/test_context.rs
+++ b/tests/test_context.rs
@@ -1,4 +1,9 @@
-use anyhow::{Context, Result};
+mod drop;
+
+use crate::drop::{DetectDrop, Flag};
+use anyhow::{Context, Error, Result};
+use std::fmt::{self, Display};
+use thiserror::Error;
 
 // https://github.com/dtolnay/anyhow/issues/18
 #[test]
@@ -7,4 +12,148 @@ fn test_inference() -> Result<()> {
     let y: u32 = x.parse().context("...")?;
     assert_eq!(y, 1);
     Ok(())
+}
+
+macro_rules! context_type {
+    ($name:ident) => {
+        #[derive(Debug)]
+        struct $name {
+            message: &'static str,
+            drop: DetectDrop,
+        }
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str(self.message)
+            }
+        }
+    };
+}
+
+context_type!(HighLevel);
+context_type!(MidLevel);
+
+#[derive(Error, Debug)]
+#[error("{message}")]
+struct LowLevel {
+    message: &'static str,
+    drop: DetectDrop,
+}
+
+struct Dropped {
+    low: Flag,
+    mid: Flag,
+    high: Flag,
+}
+
+impl Dropped {
+    fn none(&self) -> bool {
+        !self.low.get() && !self.mid.get() && !self.high.get()
+    }
+
+    fn all(&self) -> bool {
+        self.low.get() && self.mid.get() && self.high.get()
+    }
+}
+
+fn make_chain() -> (Error, Dropped) {
+    let dropped = Dropped {
+        low: Flag::new(),
+        mid: Flag::new(),
+        high: Flag::new(),
+    };
+
+    let low = LowLevel {
+        message: "no such file or directory",
+        drop: DetectDrop::new(&dropped.low),
+    };
+
+    // impl Context for Result<T, E>
+    let mid = Err::<(), LowLevel>(low)
+        .context(MidLevel {
+            message: "failed to load config",
+            drop: DetectDrop::new(&dropped.mid),
+        })
+        .unwrap_err();
+
+    // impl Context for Result<T, Error>
+    let high = Err::<(), Error>(mid)
+        .context(HighLevel {
+            message: "failed to start server",
+            drop: DetectDrop::new(&dropped.high),
+        })
+        .unwrap_err();
+
+    (high, dropped)
+}
+
+#[test]
+fn test_downcast_ref() {
+    let (err, dropped) = make_chain();
+
+    assert!(!err.is::<String>());
+    assert!(err.downcast_ref::<String>().is_none());
+
+    assert!(err.is::<HighLevel>());
+    let high = err.downcast_ref::<HighLevel>().unwrap();
+    assert_eq!(high.to_string(), "failed to start server");
+
+    assert!(err.is::<MidLevel>());
+    let mid = err.downcast_ref::<MidLevel>().unwrap();
+    assert_eq!(mid.to_string(), "failed to load config");
+
+    assert!(err.is::<LowLevel>());
+    let low = err.downcast_ref::<LowLevel>().unwrap();
+    assert_eq!(low.to_string(), "no such file or directory");
+
+    assert!(dropped.none());
+    drop(err);
+    assert!(dropped.all());
+}
+
+#[test]
+fn test_downcast_high() {
+    let (err, dropped) = make_chain();
+
+    let err = err.downcast::<HighLevel>().unwrap();
+    assert!(!dropped.high.get());
+    assert!(dropped.low.get() && dropped.mid.get());
+
+    drop(err);
+    assert!(dropped.all());
+}
+
+#[test]
+fn test_downcast_mid() {
+    let (err, dropped) = make_chain();
+
+    let err = err.downcast::<MidLevel>().unwrap();
+    assert!(!dropped.mid.get());
+    assert!(dropped.low.get() && dropped.high.get());
+
+    drop(err);
+    assert!(dropped.all());
+}
+
+#[test]
+fn test_downcast_low() {
+    let (err, dropped) = make_chain();
+
+    let err = err.downcast::<LowLevel>().unwrap();
+    assert!(!dropped.low.get());
+    assert!(dropped.mid.get() && dropped.high.get());
+
+    drop(err);
+    assert!(dropped.all());
+}
+
+#[test]
+fn test_unsuccessful_downcast() {
+    let (err, dropped) = make_chain();
+
+    let err = err.downcast::<String>().unwrap_err();
+    assert!(dropped.none());
+
+    drop(err);
+    assert!(dropped.all());
 }


### PR DESCRIPTION
From the docs:

---

> After attaching context of type `C` onto an error of type `E`, the resulting `anyhow::Error` may be downcast to `C` **or** to `E`.
>
> That is, in codebases that rely on downcasting, Anyhow's context supports both of the following use cases:
>
>   - **Attaching context whose type is insignificant onto errors whose type is used in downcasts.**
>
>     In other error libraries whose context is not designed this way, it can be risky to introduce context to existing code because new context might break existing working downcasts. In Anyhow, any downcast that worked before adding context will continue to work after you add a context, so you should freely add human-readable context to errors wherever it would be helpful.
>
>     ```rust
>     use anyhow::{Context, Result};
>
>     fn do_it() -> Result<()> {
>         helper().context("failed to complete the work")?;
>         ...
>     }
>
>     fn main() {
>         let err = do_it().unwrap_err();
>         if let Some(e) = err.downcast_ref::<SuspiciousError>() {
>             // If helper() returned SuspiciousError, this downcast will
>             // correctly succeed even with the context in between.
>         }
>     }
>     ```
>
>   - **Attaching context whose type is used in downcasts onto errors whose type is insignificant.**
>
>     Some codebases prefer to use machine-readable context to categorize lower level errors in a way that will be actionable to higher levels of the application.
>
>     ```rust
>     use anyhow::{Context, Result};
>
>     fn do_it() -> Result<()> {
>         helper().context(HelperFailed)?;
>         ...
>     }
>
>     fn main() {
>         let err = do_it().unwrap_err();
>         if let Some(e) = err.downcast_ref::<HelperFailed>() {
>             // If helper failed, this downcast will succeed because
>             // HelperFailed is the context that has been attached to
>             // that error.
>         }
>     }
>     ```

Closes #32.