### PR TITLE
Display original error message in the Display impl for ContextError

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -109,9 +109,10 @@ where
 impl<C, E> Display for ContextError<C, E>
 where
     C: Display,
+    E: Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.context, f)
+        write!(f, "{}\nCaused by: {}", self.context, self.error)
     }
 }
 


### PR DESCRIPTION
AFAIK `Debug` implementations of many error types do not to provide good error messages (e.g., [std::io::Error](https://doc.rust-lang.org/nightly/src/std/io/error.rs.html#87)).

Also, it can use `.ok().context(..)` or `.map_err(|_| ...)` when you only need context.