### PR TITLE
Rename the probe rust file to probe.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,7 +44,7 @@ fn main() {
 fn compile_probe() -> Option<ExitStatus> {
     let rustc = env::var_os("RUSTC")?;
     let out_dir = env::var_os("OUT_DIR")?;
-    let probefile = Path::new(&out_dir).join("lib.rs");
+    let probefile = Path::new(&out_dir).join("probe.rs");
     fs::write(&probefile, PROBE).ok()?;
     Command::new(rustc)
         .arg("--edition=2018")


### PR DESCRIPTION
This would help some people with build problems using [nix](https://nixos.org) or to be more specific `buildRustCrate` (but that's probably not meaningful to you).

See https://github.com/kolloch/crate2nix/issues/39 and https://github.com/NixOS/nixpkgs/issues/74071.

It is clearly a bug in buildRustCrate but if you could accept this change in the meanwhile...