### PR TITLE
Conversion from Box<dyn StdError + Send + Sync> to Error

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -45,6 +45,7 @@
 //     (&error).anyhow_kind().new(error)
 
 use crate::Error;
+use std::error::Error as StdError;
 use std::fmt::{Debug, Display};
 
 #[cfg(backtrace)]
@@ -87,5 +88,23 @@ impl Trait {
         E: Into<Error>,
     {
         error.into()
+    }
+}
+
+pub struct Boxed;
+
+pub trait BoxedKind: Sized {
+    #[inline]
+    fn anyhow_kind(&self) -> Boxed {
+        Boxed
+    }
+}
+
+impl BoxedKind for Box<dyn StdError + Send + Sync> {}
+
+impl Boxed {
+    pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
+        let backtrace = backtrace_if_absent!(error);
+        Error::from_boxed(error, backtrace)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,7 @@ pub mod private {
     #[cfg(backtrace)]
     use std::backtrace::Backtrace;
 
-    pub use crate::kind::{AdhocKind, TraitKind};
+    pub use crate::kind::{AdhocKind, BoxedKind, TraitKind};
 
     pub fn new_adhoc<M>(message: M) -> Error
     where

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -154,7 +154,7 @@ macro_rules! anyhow {
     };
     ($err:expr $(,)?) => ({
         #[allow(unused_imports)]
-        use $crate::private::{AdhocKind, TraitKind};
+        use $crate::private::{AdhocKind, BoxedKind, TraitKind};
         let error = $err;
         (&error).anyhow_kind().new(error)
     });

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -1,0 +1,40 @@
+use anyhow::anyhow;
+use std::error::Error as StdError;
+use std::io;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("outer")]
+struct MyError {
+    source: io::Error,
+}
+
+#[test]
+fn test_boxed_str() {
+    let error = Box::<dyn StdError + Send + Sync>::from("oh no!");
+    let error = anyhow!(error);
+    assert_eq!("oh no!", error.to_string());
+    assert_eq!(
+        "oh no!",
+        error
+            .downcast_ref::<Box<dyn StdError + Send + Sync>>()
+            .unwrap()
+            .to_string()
+    );
+}
+
+#[test]
+fn test_boxed_thiserror() {
+    let error = MyError {
+        source: io::Error::new(io::ErrorKind::Other, "oh no!"),
+    };
+    let error = anyhow!(error);
+    assert_eq!("oh no!", error.source().unwrap().to_string());
+}
+
+#[test]
+fn test_boxed_anyhow() {
+    let error = anyhow!("oh no!").context("it failed");
+    let error = anyhow!(error);
+    assert_eq!("oh no!", error.source().unwrap().to_string());
+}


### PR DESCRIPTION
This change exposes a cause-chain-preserving conversion from Box\<dyn StdError + Send + Sync\> to anyhow::Error.

```rust
use anyhow::{anyhow, Result};
use std::error::Error as StdError;
use std::fmt::{self, Display};

fn f() -> Result<(), Box<dyn StdError + Send + Sync>> {
    #[derive(Debug)]
    struct Error(Box<dyn StdError + Send + Sync>);
    impl Display for Error {
        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
            formatter.write_str("oh no!")
        }
    }
    impl StdError for Error {
        fn source(&self) -> Option<&(dyn StdError + 'static)> {
            Some(self.0.as_ref())
        }
    }
    let source = Box::from("it failed");
    Err(Box::new(Error(source)))
}

fn main() -> Result<()> {
    match f() {
        Err(err) => Err(anyhow!(err)),
        Ok(_) => unreachable!(),
    }
}
```

```console
Error: oh no!

Caused by:
    it failed
```