### PR TITLE
Add no_std + alloc support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ script:
 matrix:
   include:
     - rust: 1.34.0
-      script:
-        - cargo check
-        - cargo check --no-default-features
+      script: cargo check
+    - rust: 1.36.0
+      script: cargo check --no-default-features
     - rust: nightly
       name: Clippy
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ rust:
   - beta
   - stable
 
-script: cargo test
+script:
+  - cargo test
+  - cargo check --no-default-features
 
 matrix:
   include:
     - rust: 1.34.0
-      script: cargo check
+      script:
+        - cargo check
+        - cargo check --no-default-features
     - rust: nightly
       name: Clippy
       script:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,24 @@ anyhow = "1.0"
 
 <br>
 
+## No-std support
+
+In no_std mode, the same API is almost all available and works the same way. To
+depend on Anyhow in no_std mode, disable our default enabled "std" feature in
+Cargo.toml. A global allocator is required.
+
+```toml
+[dependencies]
+anyhow = { version = "1.0", default-features = false }
+```
+
+Since the `?`-based error conversions would normally rely on the
+`std::error::Error` trait which is only available through std, no_std mode will
+require an explicit `.map_err(Error::msg)` when working with a non-Anyhow error
+type inside a function that returns Anyhow's error type.
+
+<br>
+
 ## Comparison to failure
 
 The `anyhow::Error` type works something like `failure::Error`, but unlike

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -28,7 +28,7 @@ macro_rules! backtrace_if_absent {
     };
 }
 
-#[cfg(not(backtrace))]
+#[cfg(all(feature = "std", not(backtrace)))]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {
         None

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,8 +1,8 @@
 use crate::error::ContextError;
 use crate::{Context, Error};
-use std::convert::Infallible;
+use core::convert::Infallible;
+use core::fmt::{self, Debug, Display, Write};
 use std::error::Error as StdError;
-use std::fmt::{self, Debug, Display, Write};
 
 #[cfg(backtrace)]
 use std::backtrace::Backtrace;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,8 +1,7 @@
 use crate::error::ContextError;
-use crate::{Context, Error};
+use crate::{Context, Error, StdError};
 use core::convert::Infallible;
 use core::fmt::{self, Debug, Display, Write};
-use std::error::Error as StdError;
 
 #[cfg(backtrace)]
 use std::backtrace::Backtrace;
@@ -16,6 +15,7 @@ mod ext {
             C: Display + Send + Sync + 'static;
     }
 
+    #[cfg(feature = "std")]
     impl<E> StdError for E
     where
         E: std::error::Error + Send + Sync + 'static,
@@ -143,7 +143,7 @@ where
     }
 
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(&*self.error)
+        Some(self.error.inner.error())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,12 @@
 use crate::backtrace::Backtrace;
 use crate::wrapper::{BoxedError, DisplayError, MessageError};
 use crate::{Chain, Error};
-use std::any::TypeId;
+use core::any::TypeId;
+use core::fmt::{self, Debug, Display};
+use core::mem::{self, ManuallyDrop};
+use core::ops::{Deref, DerefMut};
+use core::ptr::{self, NonNull};
 use std::error::Error as StdError;
-use std::fmt::{self, Debug, Display};
-use std::mem::{self, ManuallyDrop};
-use std::ops::{Deref, DerefMut};
-use std::ptr::{self, NonNull};
 
 impl Error {
     /// Create a new error object from any error type.

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,6 +1,6 @@
 use crate::error::ErrorImpl;
 use crate::Chain;
-use std::fmt::{self, Debug};
+use core::fmt::{self, Debug};
 
 impl ErrorImpl<()> {
     pub(crate) fn display(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,5 +1,5 @@
+use crate::chain::Chain;
 use crate::error::ErrorImpl;
-use crate::Chain;
 use core::fmt::{self, Debug};
 
 impl ErrorImpl<()> {

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -46,7 +46,9 @@
 
 use crate::Error;
 use core::fmt::{Debug, Display};
-use std::error::Error as StdError;
+
+#[cfg(feature = "std")]
+use crate::StdError;
 
 #[cfg(backtrace)]
 use std::backtrace::Backtrace;
@@ -91,8 +93,10 @@ impl Trait {
     }
 }
 
+#[cfg(feature = "std")]
 pub struct Boxed;
 
+#[cfg(feature = "std")]
 pub trait BoxedKind: Sized {
     #[inline]
     fn anyhow_kind(&self) -> Boxed {
@@ -100,8 +104,10 @@ pub trait BoxedKind: Sized {
     }
 }
 
+#[cfg(feature = "std")]
 impl BoxedKind for Box<dyn StdError + Send + Sync> {}
 
+#[cfg(feature = "std")]
 impl Boxed {
     pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
         let backtrace = backtrace_if_absent!(error);

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -45,8 +45,8 @@
 //     (&error).anyhow_kind().new(error)
 
 use crate::Error;
+use core::fmt::{Debug, Display};
 use std::error::Error as StdError;
-use std::fmt::{Debug, Display};
 
 #[cfg(backtrace)]
 use std::backtrace::Backtrace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,24 @@
 //!   #     Ok(())
 //!   # }
 //!   ```
+//!
+//! <br>
+//!
+//! # No-std support
+//!
+//! In no_std mode, the same API is almost all available and works the same way.
+//! To depend on Anyhow in no_std mode, disable our default enabled "std"
+//! feature in Cargo.toml. A global allocator is required.
+//!
+//! ```toml
+//! [dependencies]
+//! anyhow = { version = "1.0", default-features = false }
+//! ```
+//!
+//! Since the `?`-based error conversions would normally rely on the
+//! `std::error::Error` trait which is only available through std, no_std mode
+//! will require an explicit `.map_err(Error::msg)` when working with a
+//! non-Anyhow error type inside a function that returns Anyhow's error type.
 
 #![doc(html_root_url = "https://docs.rs/anyhow/1.0.24")]
 #![cfg_attr(backtrace, feature(backtrace))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,8 +182,8 @@ compile_error!("no_std support is not implemented yet");
 
 use crate::chain::ChainState;
 use crate::error::ErrorImpl;
-use std::fmt::Display;
-use std::mem::ManuallyDrop;
+use core::fmt::Display;
+use core::mem::ManuallyDrop;
 
 pub use anyhow as format_err;
 
@@ -356,7 +356,7 @@ pub struct Chain<'a> {
 ///     Ok(())
 /// }
 /// ```
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// Provides the `context` method for `Result`.
 ///
@@ -517,10 +517,12 @@ pub trait Context<T, E>: context::private::Sealed {
 #[doc(hidden)]
 pub mod private {
     use crate::Error;
-    use std::fmt::{Debug, Display};
+    use core::fmt::{Debug, Display};
 
     #[cfg(backtrace)]
     use std::backtrace::Backtrace;
+
+    pub use core::result::Result::Err;
 
     #[doc(hidden)]
     pub mod kind {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,13 +50,13 @@
 #[macro_export]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return std::result::Result::Err($crate::anyhow!($msg));
+        return $crate::private::Err($crate::anyhow!($msg));
     };
     ($err:expr $(,)?) => {
-        return std::result::Result::Err($crate::anyhow!($err));
+        return $crate::private::Err($crate::anyhow!($err));
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return std::result::Result::Err($crate::anyhow!($fmt, $($arg)*));
+        return $crate::private::Err($crate::anyhow!($fmt, $($arg)*));
     };
 }
 
@@ -108,17 +108,17 @@ macro_rules! bail {
 macro_rules! ensure {
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {
-            return std::result::Result::Err($crate::anyhow!($msg));
+            return $crate::private::Err($crate::anyhow!($msg));
         }
     };
     ($cond:expr, $err:expr $(,)?) => {
         if !$cond {
-            return std::result::Result::Err($crate::anyhow!($err));
+            return $crate::private::Err($crate::anyhow!($err));
         }
     };
     ($cond:expr, $fmt:expr, $($arg:tt)*) => {
         if !$cond {
-            return std::result::Result::Err($crate::anyhow!($fmt, $($arg)*));
+            return $crate::private::Err($crate::anyhow!($fmt, $($arg)*));
         }
     };
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,5 +1,5 @@
+use core::fmt::{self, Debug, Display};
 use std::error::Error as StdError;
-use std::fmt::{self, Debug, Display};
 
 #[repr(transparent)]
 pub struct MessageError<M>(pub M);

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,5 +1,5 @@
+use crate::StdError;
 use core::fmt::{self, Debug, Display};
-use std::error::Error as StdError;
 
 #[repr(transparent)]
 pub struct MessageError<M>(pub M);
@@ -47,21 +47,25 @@ where
 
 impl<M> StdError for DisplayError<M> where M: Display + 'static {}
 
+#[cfg(feature = "std")]
 #[repr(transparent)]
 pub struct BoxedError(pub Box<dyn StdError + Send + Sync>);
 
+#[cfg(feature = "std")]
 impl Debug for BoxedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(&self.0, f)
     }
 }
 
+#[cfg(feature = "std")]
 impl Display for BoxedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
 
+#[cfg(feature = "std")]
 impl StdError for BoxedError {
     #[cfg(backtrace)]
     fn backtrace(&self) -> Option<&crate::backtrace::Backtrace> {


### PR DESCRIPTION
In no_std mode, the same API is almost all available and works the same way. To depend on Anyhow in no_std mode, disable our default enabled "std" feature in Cargo.toml. A global allocator is required.

```toml
[dependencies]
anyhow = { version = "1.0", default-features = false }
```

Since the `?`-based error conversions would normally rely on the `std::error::Error` trait which is only available through std, no_std mode will require an explicit `.map_err(Error::msg)` when working with a non-Anyhow error type inside a function that returns Anyhow's error type.

Closes #51.