### PR TITLE
Fixed a couple inconsistencies in the MessageError<M> vtable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,7 @@ impl Error {
             // Safety: we can treat treating MessageError<M> as M when
             // downcasting because it is #[repr(transparent)]
             object_downcast: object_downcast::<M>,
-            object_drop_rest: object_drop_front::<M>,
+            object_drop_rest: object_drop_front::<MessageError<M>>,
         };
 
         // Safety: MessageError is repr(transparent) so it is okay for the

--- a/src/error.rs
+++ b/src/error.rs
@@ -102,6 +102,8 @@ impl Error {
             #[cfg(feature = "std")]
             object_mut: object_mut::<MessageError<M>>,
             object_boxed: object_boxed::<MessageError<M>>,
+            // Safety: we can treat treating MessageError<M> as M when
+            // downcasting because it is #[repr(transparent)]
             object_downcast: object_downcast::<M>,
             object_drop_rest: object_drop_front::<M>,
         };


### PR DESCRIPTION
I'm doing [a review](https://github.com/Michael-F-Bryan/adventures.michaelfbryan.com/pull/8) of `anyhow` and noticed a couple inconsistencies when constructing the vtable for `MessageError<M>`. 

The current code is sound, but I thought I'd make things easier for future reviewers because I needed to spend a couple minutes reassuring myself it's okay to use something like `object_drop_front::<M>` instead of `object_drop_front::<MessageError<M>>`.

The lines I'm referring to:

```rust
pub(crate) fn from_adhoc<M>(message: M, backtrace: Option<Backtrace>) -> Self
where
    M: Display + Debug + Send + Sync + 'static,
{
    use crate::wrapper::MessageError;
    let error: MessageError<M> = MessageError(message);
    let vtable = &ErrorVTable {
        object_drop: object_drop::<MessageError<M>>,
        object_ref: object_ref::<MessageError<M>>,
        #[cfg(feature = "std")]
        object_mut: object_mut::<MessageError<M>>,
        object_boxed: object_boxed::<MessageError<M>>,
        object_downcast: object_downcast::<M>,                             <-----
        object_drop_rest: object_drop_front::<M>,                            <-----
    };

    // Safety: MessageError is repr(transparent) so it is okay for the
    // vtable to allow casting the MessageError<M> to M.
    unsafe { Error::construct(error, vtable, backtrace) }
}
```