### PR TITLE
Let ensure/bail work with Box<dyn Error>

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,13 +50,13 @@
 #[macro_export]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return $crate::private::Err($crate::anyhow!($msg));
+        return $crate::private::Err($crate::anyhow!($msg).into());
     };
     ($err:expr $(,)?) => {
-        return $crate::private::Err($crate::anyhow!($err));
+        return $crate::private::Err($crate::anyhow!($err).into());
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::private::Err($crate::anyhow!($fmt, $($arg)*));
+        return $crate::private::Err($crate::anyhow!($fmt, $($arg)*).into());
     };
 }
 
@@ -108,17 +108,17 @@ macro_rules! bail {
 macro_rules! ensure {
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {
-            return $crate::private::Err($crate::anyhow!($msg));
+            return $crate::private::Err($crate::anyhow!($msg).into());
         }
     };
     ($cond:expr, $err:expr $(,)?) => {
         if !$cond {
-            return $crate::private::Err($crate::anyhow!($err));
+            return $crate::private::Err($crate::anyhow!($err).into());
         }
     };
     ($cond:expr, $fmt:expr, $($arg:tt)*) => {
         if !$cond {
-            return $crate::private::Err($crate::anyhow!($fmt, $($arg)*));
+            return $crate::private::Err($crate::anyhow!($fmt, $($arg)*).into());
         }
     };
 }

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use self::common::*;
-use anyhow::ensure;
+use anyhow::{ensure, bail};
 
 #[test]
 fn test_messages() {
@@ -30,4 +30,19 @@ fn test_ensure() {
         Ok(())
     };
     assert!(f().is_err());
+}
+
+#[test]
+fn test_boxed_ensure() {
+    fn inner() -> Result<(), Box<dyn std::error::Error>> {
+        ensure!(true, "error");
+        Ok(())
+    }
+}
+
+#[test]
+fn test_boxed_bail() {
+    fn inner() -> Result<(), Box<dyn std::error::Error>> {
+        bail!("error");
+    }
 }


### PR DESCRIPTION
This lets you use `ensure` and `bail` in functions which return `Result<_, Box<dyn std::Error::Error>>`.

Unfortunately this does break type inference on one of the closure tests, I'm not sure if it's possible to fix that.