### PR TITLE
Simplify code to find root cause

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -343,12 +343,7 @@ impl Error {
     /// [`chain()`][Error::chain].
     #[cfg(feature = "std")]
     pub fn root_cause(&self) -> &(dyn StdError + 'static) {
-        let mut chain = self.chain();
-        let mut root_cause = chain.next().unwrap();
-        for cause in chain {
-            root_cause = cause;
-        }
-        root_cause
+        self.chain().last().unwrap()
     }
 
     /// Returns true if `E` is the type held by this error object.


### PR DESCRIPTION
Since `chain` is an iterator, why not use it!