### PR TITLE
Don't emit trailing semicolon from `bail!`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -53,13 +53,13 @@
 #[macro_export]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return $crate::private::Err($crate::anyhow!($msg));
+        return $crate::private::Err($crate::anyhow!($msg))
     };
     ($err:expr $(,)?) => {
-        return $crate::private::Err($crate::anyhow!($err));
+        return $crate::private::Err($crate::anyhow!($err))
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::private::Err($crate::anyhow!($fmt, $($arg)*));
+        return $crate::private::Err($crate::anyhow!($fmt, $($arg)*))
     };
 }
 


### PR DESCRIPTION
This will allow `bail!` to continue to be used in expression position if
https://github.com/rust-lang/rust/issues/33953 is fixed