### PR TITLE
Support round tripping anyhow::Error over C FFI as void*

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,7 @@ pub use anyhow as format_err;
 ///     # Ok(())
 /// }
 /// ```
+#[repr(transparent)]
 pub struct Error {
     inner: ManuallyDrop<Box<ErrorImpl<()>>>,
 }

--- a/tests/test_ffi.rs
+++ b/tests/test_ffi.rs
@@ -1,4 +1,4 @@
-#![warn(improper_ctypes, improper_ctypes_definitions)]
+#![deny(improper_ctypes, improper_ctypes_definitions)]
 
 use anyhow::anyhow;
 

--- a/tests/test_ffi.rs
+++ b/tests/test_ffi.rs
@@ -1,0 +1,18 @@
+#![warn(improper_ctypes, improper_ctypes_definitions)]
+
+use anyhow::anyhow;
+
+#[no_mangle]
+pub extern "C" fn anyhow1(err: anyhow::Error) {
+    println!("{:?}", err);
+}
+
+#[no_mangle]
+pub extern "C" fn anyhow2(err: &mut Option<anyhow::Error>) {
+    *err = Some(anyhow!("ffi error"));
+}
+
+#[no_mangle]
+pub extern "C" fn anyhow3() -> Option<anyhow::Error> {
+    Some(anyhow!("ffi error"))
+}


### PR DESCRIPTION
Relevant to https://github.com/dtolnay/cxx/issues/290.