### PR TITLE
Improve error on temp value to point to the correct statement

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -173,8 +173,9 @@ macro_rules! anyhow {
     };
     ($err:expr $(,)?) => ({
         use $crate::private::kind::*;
-        let error = $err;
-        (&error).anyhow_kind().new(error)
+        match $err {
+            error => (&error).anyhow_kind().new(error),
+        }
     });
     ($fmt:expr, $($arg:tt)*) => {
         $crate::private::new_adhoc(format!($fmt, $($arg)*))

--- a/tests/ui/temporary-value.rs
+++ b/tests/ui/temporary-value.rs
@@ -1,0 +1,5 @@
+use anyhow::anyhow;
+
+fn main() {
+    let _ = anyhow!(&String::new());
+}

--- a/tests/ui/temporary-value.stderr
+++ b/tests/ui/temporary-value.stderr
@@ -1,0 +1,9 @@
+error[E0716]: temporary value dropped while borrowed
+ --> $DIR/temporary-value.rs:4:22
+  |
+4 |     let _ = anyhow!(&String::new());
+  |             ---------^^^^^^^^^^^^^-
+  |             |        |
+  |             |        creates a temporary which is freed while still in use
+  |             temporary value is freed at the end of this statement
+  |             argument requires that borrow lasts for `'static`

--- a/tests/ui/temporary-value.stderr
+++ b/tests/ui/temporary-value.stderr
@@ -2,8 +2,7 @@ error[E0716]: temporary value dropped while borrowed
  --> $DIR/temporary-value.rs:4:22
   |
 4 |     let _ = anyhow!(&String::new());
-  |             ---------^^^^^^^^^^^^^-
+  |             ---------^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
   |             |        |
   |             |        creates a temporary which is freed while still in use
-  |             temporary value is freed at the end of this statement
   |             argument requires that borrow lasts for `'static`


### PR DESCRIPTION
The error used to point to a statement "inside" the macro invocation, rather than a real statement that makes sense from the user's point of view.

**Before:**

```console
error[E0716]: temporary value dropped while borrowed
 --> $DIR/temporary-value.rs:4:22
  |
4 |     let _ = anyhow!(&String::new());
  |             ---------^^^^^^^^^^^^^-
  |             |        |
  |             |        creates a temporary which is freed while still in use
  |             temporary value is freed at the end of this statement
  |             argument requires that borrow lasts for `'static`
```

**After:**

```console
error[E0716]: temporary value dropped while borrowed
 --> $DIR/temporary-value.rs:4:22
  |
4 |     let _ = anyhow!(&String::new());
  |             ---------^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
  |             |        |
  |             |        creates a temporary which is freed while still in use
  |             argument requires that borrow lasts for `'static`
```