### PR TITLE
Allow test suite to pass under miri, and fix various other miri/stacked borrow issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@clippy
       - run: cargo clippy --tests -- -Dclippy::all -Dclippy::pedantic
+
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - run: cargo miri test

--- a/src/context.rs
+++ b/src/context.rs
@@ -143,7 +143,7 @@ where
     }
 
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(self.error.inner.error())
+        Some(unsafe { crate::ErrorImpl::error(self.error.inner) })
     }
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,13 +1,14 @@
 use crate::chain::Chain;
 use crate::error::ErrorImpl;
 use core::fmt::{self, Debug, Write};
+use core::ptr::NonNull;
 
 impl ErrorImpl<()> {
-    pub(crate) fn display(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.error())?;
+    pub(crate) unsafe fn display(this: NonNull<Self>, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", Self::error(this))?;
 
         if f.alternate() {
-            for cause in self.chain().skip(1) {
+            for cause in Self::chain(this).skip(1) {
                 write!(f, ": {}", cause)?;
             }
         }
@@ -15,8 +16,8 @@ impl ErrorImpl<()> {
         Ok(())
     }
 
-    pub(crate) fn debug(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let error = self.error();
+    pub(crate) unsafe fn debug(this: NonNull<Self>, f: &mut fmt::Formatter) -> fmt::Result {
+        let error = Self::error(this);
 
         if f.alternate() {
             return Debug::fmt(error, f);
@@ -42,7 +43,7 @@ impl ErrorImpl<()> {
         {
             use std::backtrace::BacktraceStatus;
 
-            let backtrace = self.backtrace();
+            let backtrace = Self::backtrace(this);
             if let BacktraceStatus::Captured = backtrace.status() {
                 let mut backtrace = backtrace.to_string();
                 write!(f, "\n\n")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,10 +248,9 @@ mod kind;
 mod macros;
 mod wrapper;
 
-use crate::alloc::Box;
 use crate::error::ErrorImpl;
 use core::fmt::Display;
-use core::mem::ManuallyDrop;
+use core::ptr::NonNull;
 
 #[cfg(not(feature = "std"))]
 use core::fmt::Debug;
@@ -371,8 +370,11 @@ pub use anyhow as format_err;
 /// ```
 #[repr(transparent)]
 pub struct Error {
-    inner: ManuallyDrop<Box<ErrorImpl<()>>>,
+    inner: NonNull<ErrorImpl<()>>,
 }
+
+unsafe impl Send for Error {}
+unsafe impl Sync for Error {}
 
 /// Iterator of a chain of source errors.
 ///

--- a/tests/test_downcast.rs
+++ b/tests/test_downcast.rs
@@ -68,6 +68,12 @@ fn test_downcast_mut() {
             .unwrap()
             .to_string(),
     );
+
+    let mut bailed = bail_fmt().unwrap_err();
+    *bailed.downcast_mut::<String>().unwrap() = "clobber".to_string();
+    assert_eq!(bailed.downcast_ref::<String>().unwrap(), "clobber");
+    assert_eq!(bailed.downcast_mut::<String>().unwrap(), "clobber");
+    assert_eq!(bailed.downcast::<String>().unwrap(), "clobber");
 }
 
 #[test]


### PR DESCRIPTION
There are a few things that anyhow does that are currently considered unsound by miri and stacked borrows, this fixes them to the best of my ability. After this, the test suite passes under miri. It also cases where miri didn't complain, but appeared to be unsound (that said the tests don't write to error types a lot).

I'd understand if you don't like the way I've done some things, I kind of expect if this is to land it would need at least a round of review to clean it up further, as some of the stuff doesn't make as much sense now.

## Changes

Anyway, I've tried to make this happen a few times and it's mostly evaded me. This time I managed to get it working.

These are, broadly, the changes it makes, and why I made them, so that you have hopefully enough context to feel in-the-loop for reviewing.

- Avoids using `Box<ErrorImpl<()>>` There are reasons for this:
    1. Converting between `Box<T>` and `Box<U>` where `T` and `U` don't have the same layout is UB in many (all?) cases (for example: if U is larger than T it is definitely UB for reasons mentioned in the second bit)
    2. This avoids the situations where have a not-entirely-unique `Box<T>`, for example when we read one out of a ManuallyDrop field, and such. `ManuallyDrop` doesn't save us here, since it has no impact on aliasing or validity. We could have uses `MaybeUninit` instead, but just using NonNull is cleaner.

     See https://github.com/rust-lang/unsafe-code-guidelines/issues/258

- Avoids `&ErrorImpl<()>`, `&mut ErrorImpl<()>` essentially everywhere. There are too many ways this can go wrong. The most notable one that anyhow hits is that it likes to turn `&ErrorImpl<()>` into `&ErrorImpl<E>`, where `E` is bigger than `()`.

    Currently this is UB. The mental model I use for this is that the first borrows is only for one specific range of bytes, and so you don't get to decide that you're borrowing more. (It kinda sucks and applies to Box<T> too)

    See https://github.com/rust-lang/unsafe-code-guidelines/issues/256

    The other reason for this change is that in general the code seemed to play it pretty fast and lose with pointers, which can be fine, but (among other things) sorta requires they be raw.

    That said, I was a bit more paranoid than perhaps I need to be here, both because the kind of code that would cause issues (mutable access) isn't well covered by tests, and because it's easier to just follow a rule of "always avoid `&ErrorImpl<()>`" rather than a lot of thinking about it a ton.

- Avoids cases where we go `&T` => `*const T` => `*mut T` => `&mut T`.

    Annoyingly, it turns out it's not 100% true that const/mut are equivalent. Pointers that start out as const are illegal to ever write to. The biggest change was that a distinct downcast_mut function was needed in the vtable, but i think there were smaller onces.

    See https://github.com/rust-lang/unsafe-code-guidelines/issues/257

That's probably it.

Note: I also switched things away from using transumute in favor of raw ptr conversions, but in retrospect the transmute would have definitely been fine, even between NonNull/Box, so if you prefer them I can try and undo that part.

## Options for cleaning this all up

So, again, I'm unsurprised if you'd rather not take it as is. It makes a lot more code unsafe, and harder to work with.

Sadly, using references is a bit of a double-edged sword. They make maintenance easier, but also make it much easier to have unsound code, since they let the compiler assume so much about what's allowed. And instead, using pointers greatly increases how much unsafe code there is (any function taking a pointer it reads from needs to be).

One option to improve things if you'd like would be add a transparent wrapper for `NonNull<ErrorImpl<()>>` that would have more ref-like semantics, hold a lifetime, and allow use from safe code (it would just be unsafe to create). (Then, stuff like `ErrorImpl::{display,debug,error,backtrace,error_mut,etc}` could be safe again, and it could be used in vtable functions to make some ref/mut versions more obviously distinct).

I didn't do this for a few reasons:
- adds complexity, you'd have to sort out which bits are required and which are are just to make things nicer.
- you might have a different design you'd prefer to clean this up
- you might not want to take the patch at all (or might want to take it as is)

Oh, other big missing thing is that I need to update safety annotations on several comments, but I figured I'd do a temp check on this first.

---

Anyway, for clarity: I don't think any of these issues can cause any problems in practice under current compilers. It's possible that for several of them the outcome will be "stacked borrows is wrong".

That said, it feels plausible that at least some of these are real problems, and is nice if code that uses anyhow can use miri too, even if they happen to test a case that triggers an error.

P.S. very sorry for writing an whole dang novel about this PR. It's complex and didn't want to just drop it with no context, since I know how that can be.