### PR TITLE
Indicate a doc_cfg on the Error backtrace() method

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -309,6 +309,7 @@ impl Error {
     ///
     /// [tracking]: https://github.com/rust-lang/rust/issues/53487
     #[cfg(backtrace)]
+    #[cfg_attr(doc_cfg, doc(cfg(nightly)))]
     pub fn backtrace(&self) -> &Backtrace {
         unsafe { ErrorImpl::backtrace(self.inner.by_ref()) }
     }


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/1940490/111857373-3d7b0b00-88ee-11eb-8ad9-f0fb0279e654.png" width="600">