### PR TITLE
Eliminate functionally duplicate vtable methods on rustc 1.51+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [nightly, beta, stable, 1.51.0, 1.50.0]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master

--- a/build.rs
+++ b/build.rs
@@ -56,6 +56,10 @@ fn main() {
     if rustc < 38 {
         println!("cargo:rustc-cfg=anyhow_no_macro_reexport");
     }
+
+    if rustc < 51 {
+        println!("cargo:rustc-cfg=anyhow_no_ptr_addr_of");
+    }
 }
 
 fn compile_probe() -> Option<ExitStatus> {

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -91,11 +91,32 @@ where
         }
     }
 
+    #[cfg(not(anyhow_no_ptr_addr_of))]
+    pub fn from_raw(ptr: NonNull<T>) -> Self {
+        Ref {
+            ptr,
+            lifetime: PhantomData,
+        }
+    }
+
     pub fn cast<U: CastTo>(self) -> Ref<'a, U::Target> {
         Ref {
             ptr: self.ptr.cast(),
             lifetime: PhantomData,
         }
+    }
+
+    #[cfg(not(anyhow_no_ptr_addr_of))]
+    pub fn by_mut(self) -> Mut<'a, T> {
+        Mut {
+            ptr: self.ptr,
+            lifetime: PhantomData,
+        }
+    }
+
+    #[cfg(not(anyhow_no_ptr_addr_of))]
+    pub fn as_ptr(self) -> *const T {
+        self.ptr.as_ptr() as *const T
     }
 
     pub unsafe fn deref(self) -> &'a T {
@@ -127,6 +148,7 @@ impl<'a, T> Mut<'a, T>
 where
     T: ?Sized,
 {
+    #[cfg(anyhow_no_ptr_addr_of)]
     pub fn new(ptr: &'a mut T) -> Self {
         Mut {
             ptr: NonNull::from(ptr),
@@ -137,6 +159,14 @@ where
     pub fn cast<U: CastTo>(self) -> Mut<'a, U::Target> {
         Mut {
             ptr: self.ptr.cast(),
+            lifetime: PhantomData,
+        }
+    }
+
+    #[cfg(not(anyhow_no_ptr_addr_of))]
+    pub fn by_ref(self) -> Ref<'a, T> {
+        Ref {
+            ptr: self.ptr,
             lifetime: PhantomData,
         }
     }


### PR DESCRIPTION
Using the raw pointer addr_of macro, it's possible for the vtable methods to avoid instantiating *any* `&` or `&mut` and operate only in terms of pointers, allowing `Deref` and `DerefMut` to reuse a single piece of vtable logic, and `downcast_ref` and `downcast_mut` to reuse a single piece.

Closes #62.
FYI @thomcc