### PR TITLE
Add ensure_eq and ensure_ne macros to mirror assert

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -136,6 +136,178 @@ macro_rules! ensure {
     };
 }
 
+///  Return early with an error if two expressions are not equal to each other.
+///
+/// The surrounding function's or closure's return value is required to be
+/// `Result<_,`[`anyhow::Error`][crate::Error]`>`.
+///
+/// Analogously to `assert_eq!`, `ensure_eq!` takes two expressions and exits
+/// the function if they are not equal to each other. Unlike `assert_eq!`,
+/// `ensure_eq!` returns an `Error` rather than panicking.
+///
+/// # Example
+///
+/// ```
+/// # use anyhow::{ensure_eq, Result};
+/// #
+/// # fn main() -> Result<()> {
+/// #     let user_id = 2;
+/// #     let allowed_id = 2;
+/// #
+/// ensure_eq!(user_id, allowed_id, "user is not allowed");
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// ```
+/// # use anyhow::{ensure_eq, Result};
+/// # use thiserror::Error;
+/// #
+/// #[derive(Error, Debug)]
+/// enum SecurityError {
+///     #[error("permission is denied")]
+///     PermissionDenied,
+///     # #[error("...")]
+///     # More = (stringify! {
+///     ...
+///     # }, 1).1,
+/// }
+///
+/// # fn main() -> Result<()> {
+/// #     let username = "admin";
+/// #
+/// ensure_eq!(username, "admin", SecurityError::PermissionDenied);
+/// #     Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! ensure_eq {
+    ($left:expr, $right:expr $(,)?) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    return $crate::private::Err($crate::anyhow!(r#"Condition failed: `(left == right)`
+    left: `{:?}`,
+   right: `{:?}`"#, &*left_val, &*right_val));
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $msg:literal $(,)?) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    return $crate::private::Err($crate::anyhow!($msg));
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $err:expr $(,)?) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    return $crate::private::Err($crate::anyhow!($err));
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $fmt:expr, $($arg:tt)+) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    return $crate::private::Err($crate::anyhow!($fmt, $($arg)+));
+                }
+            }
+        }
+    };
+}
+
+///  Return early with an error if two expressions are equal to each other.
+///
+/// The surrounding function's or closure's return value is required to be
+/// `Result<_,`[`anyhow::Error`][crate::Error]`>`.
+///
+/// Analogously to `assert_ne!`, `ensure_ne!` takes two expressions and exits
+/// the function if they are equal to each other. Unlike `assert_ne!`, `ensure_ne!`
+/// returns an `Error` rather than panicking.
+///
+/// # Example
+///
+/// ```
+/// # use anyhow::{ensure_ne, Result};
+/// #
+/// # fn main() -> Result<()> {
+/// #     let user_id = 3;
+/// #     let banned_id = 2;
+/// #
+/// ensure_ne!(user_id, banned_id, "user is not allowed");
+/// #     Ok(())
+/// # }
+/// ```
+///
+/// ```
+/// # use anyhow::{ensure_ne, Result};
+/// # use thiserror::Error;
+/// #
+/// #[derive(Error, Debug)]
+/// enum FileParseError {
+///     #[error("file is empty")]
+///     Empty,
+///     # #[error("...")]
+///     # More = (stringify! {
+///     ...
+///     # }, 1).1,
+/// }
+///
+/// # fn main() -> Result<()> {
+/// #     let size = 128;
+/// #
+/// ensure_ne!(size, 0, FileParseError::Empty);
+/// #     Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! ensure_ne {
+    ($left:expr, $right:expr $(,)?) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    return $crate::private::Err($crate::anyhow!(r#"Condition failed: `(left != right)`
+    left: `{:?}`,
+   right: `{:?}`"#, &*left_val, &*right_val));
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $msg:literal $(,)?) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    return $crate::private::Err($crate::anyhow!($msg));
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $err:expr $(,)?) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    return $crate::private::Err($crate::anyhow!($err));
+                }
+            }
+        }
+    };
+    ($left:expr, $right:expr, $fmt:expr, $($arg:tt)+) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    return $crate::private::Err($crate::anyhow!($fmt, $($arg)+));
+                }
+            }
+        }
+    };
+}
+
 /// Construct an ad-hoc error from a string or existing non-`anyhow` error
 /// value.
 ///

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use self::common::*;
-use anyhow::ensure;
+use anyhow::{ensure, ensure_eq, ensure_ne};
 
 #[test]
 fn test_messages() {
@@ -40,5 +40,71 @@ fn test_ensure() {
     assert_eq!(
         f().unwrap_err().to_string(),
         "Condition failed: `v + v == 1`",
+    );
+}
+
+#[test]
+fn test_ensure_eq() {
+    let f = || {
+        ensure_eq!(1 + 1, 2, "This is correct");
+        Ok(())
+    };
+    assert!(f().is_ok());
+
+    let v = 1;
+    let f = || {
+        ensure_eq!(v + v, 2, "This is correct, v: {}", v);
+        Ok(())
+    };
+    assert!(f().is_ok());
+
+    let f = || {
+        ensure_eq!(v + v, 1, "This is not correct, v: {}", v);
+        Ok(())
+    };
+    assert!(f().is_err());
+
+    let f = || {
+        ensure_eq!(v + v, 1);
+        Ok(())
+    };
+    assert_eq!(
+        f().unwrap_err().to_string(),
+        r#"Condition failed: `(left == right)`
+    left: `2`,
+   right: `1`"#,
+    );
+}
+
+#[test]
+fn test_ensure_ne() {
+    let f = || {
+        ensure_ne!(1 + 2, 2, "This is correct");
+        Ok(())
+    };
+    assert!(f().is_ok());
+
+    let v = 1;
+    let f = || {
+        ensure_ne!(v + v, 3, "This is correct, v: {}", v);
+        Ok(())
+    };
+    assert!(f().is_ok());
+
+    let f = || {
+        ensure_ne!(v + v, 2, "This is not correct, v: {}", v);
+        Ok(())
+    };
+    assert!(f().is_err());
+
+    let f = || {
+        ensure_ne!(v + v, 2);
+        Ok(())
+    };
+    assert_eq!(
+        f().unwrap_err().to_string(),
+        r#"Condition failed: `(left != right)`
+    left: `2`,
+   right: `2`"#,
     );
 }


### PR DESCRIPTION
This adds two macros `ensure_eq` and `ensure_ne` that mirror the std's
`assert_eq` and `assert_ne` but return an Error rather than panic.

The macros accept the same 4 variants as `ensure`:

```
ensure_eq!(a, b);
ensure_eq!(a, b, "message");
ensure_eq!(a, b, MyEnum::MyError);
ensure_eq!(a, b, "error: {:?} is wrong", b);
```

And is implemented like `assert_eq/ne`, with the same default error
message:

```
Condition failed: `(left == right)`
    left: `2`,
   right: `1`
```

Fixes #140.

---

I've found myself wanting those macros several times, and there is also a ticket, so here it is :).