### PR TITLE
Depend on a recent-enough version of backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-backtrace = { version = "0.3", optional = true }
+backtrace = { version = "^0.3.51", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false }


### PR DESCRIPTION
If backtrace v0.3.50 or earlier is used, the following compile errors result:

```
error[E0599]: no method named `print_raw_with_column` found for struct `BacktraceFrameFmt<'_, '_, '_>` in the current scope
   --> /Users/john/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.40/src/backtrace.rs:284:27
    |
284 |                         f.print_raw_with_column(
    |                           ^^^^^^^^^^^^^^^^^^^^^ method not found in `BacktraceFrameFmt<'_, '_, '_>`

error[E0599]: no method named `colno` found for reference `&Symbol` in the current scope
   --> /Users/john/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.40/src/backtrace.rs:353:39
    |
353 |                         colno: symbol.colno(),
    |                                       ^^^^^ method not found in `&Symbol`

```

`print_raw_with_column` and `colno` were added in [this PR](https://github.com/rust-lang/backtrace-rs/commit/4b8f2be2a6079860e4f39c7c3133c17be705b173), and the earliest backtrace version they are available in is 0.3.51.