### PR TITLE
Add to README using backtraces on stable channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ anyhow = "1.0"
   }
   ```
 
-- If using the nightly channel, a backtrace is captured and printed with the
-  error if the underlying error type does not already provide its own. In order
-  to see backtraces, they must be enabled through the environment variables
-  described in [`std::backtrace`]:
+- If using the stable channel with enabled "backtrace" feature or the nightly
+  channel, a backtrace is captured and printed with the error if the underlying
+  error type does not already provide its own. In order to see backtraces, they
+  must be enabled through the environment variables described in
+  [`std::backtrace`]:
 
   - If you want panics and errors to both have backtraces, set
     `RUST_BACKTRACE=1`;


### PR DESCRIPTION
After reading the README I thought backtraces cannot be used on the stable Rust until I went searching through the issues and found this PR https://github.com/dtolnay/anyhow/pull/143.