### PR TITLE
Mark error constructors cold

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -24,6 +24,7 @@ pub(crate) enum ChainState<'a> {
 }
 
 impl<'a> Chain<'a> {
+    #[cold]
     pub fn new(head: &'a (dyn StdError + 'static)) -> Self {
         Chain {
             state: ChainState::Linked { next: Some(head) },

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ impl Error {
     /// created here to ensure that a backtrace exists.
     #[cfg(feature = "std")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+    #[cold]
     pub fn new<E>(error: E) -> Self
     where
         E: StdError + Send + Sync + 'static,
@@ -70,6 +71,7 @@ impl Error {
     ///         .await
     /// }
     /// ```
+    #[cold]
     pub fn msg<M>(message: M) -> Self
     where
         M: Display + Debug + Send + Sync + 'static,
@@ -78,6 +80,7 @@ impl Error {
     }
 
     #[cfg(feature = "std")]
+    #[cold]
     pub(crate) fn from_std<E>(error: E, backtrace: Option<Backtrace>) -> Self
     where
         E: StdError + Send + Sync + 'static,
@@ -100,6 +103,7 @@ impl Error {
         unsafe { Error::construct(error, vtable, backtrace) }
     }
 
+    #[cold]
     pub(crate) fn from_adhoc<M>(message: M, backtrace: Option<Backtrace>) -> Self
     where
         M: Display + Debug + Send + Sync + 'static,
@@ -125,6 +129,7 @@ impl Error {
         unsafe { Error::construct(error, vtable, backtrace) }
     }
 
+    #[cold]
     pub(crate) fn from_display<M>(message: M, backtrace: Option<Backtrace>) -> Self
     where
         M: Display + Send + Sync + 'static,
@@ -151,6 +156,7 @@ impl Error {
     }
 
     #[cfg(feature = "std")]
+    #[cold]
     pub(crate) fn from_context<C, E>(context: C, error: E, backtrace: Option<Backtrace>) -> Self
     where
         C: Display + Send + Sync + 'static,
@@ -177,6 +183,7 @@ impl Error {
     }
 
     #[cfg(feature = "std")]
+    #[cold]
     pub(crate) fn from_boxed(
         error: Box<dyn StdError + Send + Sync>,
         backtrace: Option<Backtrace>,
@@ -207,6 +214,7 @@ impl Error {
     //
     // Unsafe because the given vtable must have sensible behavior on the error
     // value of type E.
+    #[cold]
     unsafe fn construct<E>(
         error: E,
         vtable: &'static ErrorVTable,
@@ -284,6 +292,7 @@ impl Error {
     ///     })
     /// }
     /// ```
+    #[cold]
     pub fn context<C>(self, context: C) -> Self
     where
         C: Display + Send + Sync + 'static,
@@ -373,6 +382,7 @@ impl Error {
     /// ```
     #[cfg(feature = "std")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+    #[cold]
     pub fn chain(&self) -> Chain {
         unsafe { ErrorImpl::chain(self.inner.by_ref()) }
     }
@@ -515,6 +525,7 @@ impl<E> From<E> for Error
 where
     E: StdError + Send + Sync + 'static,
 {
+    #[cold]
     fn from(error: E) -> Self {
         let backtrace = backtrace_if_absent!(error);
         Error::from_std(error, backtrace)
@@ -879,6 +890,7 @@ impl ErrorImpl {
             .expect("backtrace capture failed")
     }
 
+    #[cold]
     pub(crate) unsafe fn chain(this: Ref<Self>) -> Chain {
         Chain::new(Self::error(this))
     }
@@ -917,6 +929,7 @@ where
 }
 
 impl From<Error> for Box<dyn StdError + Send + Sync + 'static> {
+    #[cold]
     fn from(error: Error) -> Self {
         let outer = ManuallyDrop::new(error);
         unsafe {

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -62,6 +62,7 @@ pub trait AdhocKind: Sized {
 impl<T> AdhocKind for &T where T: ?Sized + Display + Debug + Send + Sync + 'static {}
 
 impl Adhoc {
+    #[cold]
     pub fn new<M>(self, message: M) -> Error
     where
         M: Display + Debug + Send + Sync + 'static,
@@ -82,6 +83,7 @@ pub trait TraitKind: Sized {
 impl<E> TraitKind for E where E: Into<Error> {}
 
 impl Trait {
+    #[cold]
     pub fn new<E>(self, error: E) -> Error
     where
         E: Into<Error>,
@@ -106,6 +108,7 @@ impl BoxedKind for Box<dyn StdError + Send + Sync> {}
 
 #[cfg(feature = "std")]
 impl Boxed {
+    #[cold]
     pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
         let backtrace = backtrace_if_absent!(error);
         Error::from_boxed(error, backtrace)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,6 +626,7 @@ pub mod private {
         pub use crate::kind::BoxedKind;
     }
 
+    #[cold]
     pub fn new_adhoc<M>(message: M) -> Error
     where
         M: Display + Debug + Send + Sync + 'static,


### PR DESCRIPTION
All `#[cold]` to all error constructors.

As discussed in the [issue #165](https://github.com/dtolnay/anyhow/issues/165),
marking functions cold helps LLVM optimize code paths not leading to error.

Although in our case marking only `from` was enough, I took the
liberty of marking all error constructors `#[cold]`.

Note, I marked cold both inner function and public functions, because
LLVM does not always takes into account `#[cold]` attribute of inlined functions,
see [an example in compiled explorer](https://rust.godbolt.org/z/vzxazMMnb).