### PR TITLE
Bypass anyhow_kind-based dispatch for ensure! with default msg

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -114,10 +114,11 @@ macro_rules! bail {
 #[macro_export]
 macro_rules! ensure {
     ($cond:expr $(,)?) => {
-        $crate::ensure!(
-            $cond,
-            $crate::private::concat!("Condition failed: `", $crate::private::stringify!($cond), "`"),
-        )
+        if !$cond {
+            return $crate::private::Err($crate::private::new_adhoc(
+                $crate::private::concat!("Condition failed: `", $crate::private::stringify!($cond), "`")
+            ));
+        }
     };
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {


### PR DESCRIPTION
For `ensure!(1 < 2)`, **Before:**

```rust
if !(1 < 2) {
    return $crate::private::Err({
        use $crate::private::kind::*;
        match "Condition failed: `1 < 2`" {
            error => (&error).anyhow_kind().new(error),
        }
    });
}
```

**After:**

```rust
if !(1 < 2) {
    return $crate::private::Err($crate::private::new_adhoc("Condition failed: `1 < 2`"));
}
```