### PR TITLE
Add Send/Sync bounds to Own

### DIFF
--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -10,9 +10,9 @@ where
     pub ptr: NonNull<T>,
 }
 
-unsafe impl<T> Send for Own<T> where T: ?Sized {}
+unsafe impl<T> Send for Own<T> where T: ?Sized + Send + Sync {}
 
-unsafe impl<T> Sync for Own<T> where T: ?Sized {}
+unsafe impl<T> Sync for Own<T> where T: ?Sized + Send + Sync {}
 
 impl<T> Copy for Own<T> where T: ?Sized {}
 


### PR DESCRIPTION
I noticed the bounds were wrong. I've waffled about sending the PR, because it's not really that helpful in practice. That said here are some questions I'd ask if I were reviewing this PR[^ask]. 

[^ask]: Actually, I'd probably assume it was a drive-by PR that came without thought. which it was, although by the time I finished writing this, it wasn't.

- Does it fix any bug?

    No. it's an internal API, which is always used properly.

- Can it help catch bugs that wouldn't otherwise be caught?

    I don't know.

    The two obvious ones you want to catch are "If `ErrorImpl` itself becomes `!Send/!Sync`" and "If something `!Send/!Sync` gets put inside an `ErrorImpl`", and both of these are handled in other[^1] places[^2], even if one place makes a mistake.

    It *would* help catch issues if you put anything else inside an `Own<T>` though.
    
    It would also help future contributors, other people emulating these types (totally seems like a thing that could happen), or even forks (as has happened before). That said, those people will need to understand the types here anyway in order to use them correctly, and these issues aren't really your job to worry about (aside from future contributors, arguably).

- Why are the bounds both `Send + Sync` and not `T: Send` for `Send` and `T: Sync` for `Sync`?

    Because `Own<T>` is clone/copy. If `Own<T>` weren't, then `Own<T>: Send where T: Send` and `Own<T>: Sync where T: Sync` is enough. The copying doesn't actually matter — it only happens briefly and seems just to make the vtable functions easier to call, but the code works as-is with the correct bounds, and it seems better to use the correct bounds if the goal is detecting surprising issues.

    But you can always relax them later.

All that said, I won't be offended if you don't merge this. 

*(P.S. Sorry, accidentally submitted the PR before finishing this comment. Also, didn't intend to submit as a draft PR initially).*

[^1]: If you ever accidentally made ErrorImpl `!Send` / `!Sync`, you'll still get a compile error from [this function](https://github.com/dtolnay/anyhow/blob/master/src/error.rs#L636-L642), which requires `ErrorImpl<E>: Send + Sync`.

[^2]: If you ever try to put a !Send or !Sync type into an ErrorImpl, you'll hit a compile error here https://github.com/dtolnay/anyhow/blob/master/src/error.rs#L218-L239.
