### PR TITLE
Replace macro-generated calls to new_adhoc with Error::msg public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,9 +613,6 @@ pub trait Context<T, E>: context::private::Sealed {
 // Not public API. Referenced by macro-generated code.
 #[doc(hidden)]
 pub mod private {
-    use crate::Error;
-    use core::fmt::{Debug, Display};
-
     pub use core::result::Result::Err;
 
     #[doc(hidden)]
@@ -624,14 +621,6 @@ pub mod private {
 
         #[cfg(feature = "std")]
         pub use crate::kind::BoxedKind;
-    }
-
-    #[cold]
-    pub fn new_adhoc<M>(message: M) -> Error
-    where
-        M: Display + Debug + Send + Sync + 'static,
-    {
-        Error::from_adhoc(message, backtrace!())
     }
 
     #[cfg(anyhow_no_macro_reexport)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -115,7 +115,7 @@ macro_rules! bail {
 macro_rules! ensure {
     ($cond:expr $(,)?) => {
         if !$cond {
-            return $crate::private::Err($crate::private::new_adhoc(
+            return $crate::private::Err($crate::Error::msg(
                 $crate::private::concat!("Condition failed: `", $crate::private::stringify!($cond), "`")
             ));
         }
@@ -170,7 +170,7 @@ macro_rules! anyhow {
     ($msg:literal $(,)?) => {
         // Handle $:literal as a special case to make cargo-expanded code more
         // concise in the common case.
-        $crate::private::new_adhoc($msg)
+        $crate::Error::msg($msg)
     };
     ($err:expr $(,)?) => ({
         use $crate::private::kind::*;
@@ -179,6 +179,6 @@ macro_rules! anyhow {
         }
     });
     ($fmt:expr, $($arg:tt)*) => {
-        $crate::private::new_adhoc(format!($fmt, $($arg)*))
+        $crate::Error::msg(format!($fmt, $($arg)*))
     };
 }


### PR DESCRIPTION
The non-public `new_adhoc` function predates the introduction of `Error::msg` as a public constructor on Error. These days they do the exact same thing so it's way better for our macros to use the public one.