### PR TITLE
Refer to format macro by absolute path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@
 
 mod alloc {
     #[cfg(not(feature = "std"))]
-    extern crate alloc;
+    pub extern crate alloc;
 
     #[cfg(not(feature = "std"))]
     pub use alloc::boxed::Box;
@@ -624,9 +624,16 @@ pub mod private {
     }
 
     #[cfg(anyhow_no_macro_reexport)]
-    pub use crate::{__anyhow_concat as concat, __anyhow_stringify as stringify};
+    pub use crate::{
+        __anyhow_concat as concat, __anyhow_format as format, __anyhow_stringify as stringify,
+    };
     #[cfg(not(anyhow_no_macro_reexport))]
     pub use core::{concat, stringify};
+
+    #[cfg(all(not(anyhow_no_macro_reexport), not(feature = "std")))]
+    pub use crate::alloc::alloc::format;
+    #[cfg(all(not(anyhow_no_macro_reexport), feature = "std"))]
+    pub use std::format;
 
     #[cfg(anyhow_no_macro_reexport)]
     #[doc(hidden)]
@@ -634,6 +641,15 @@ pub mod private {
     macro_rules! __anyhow_concat {
         ($($tt:tt)*) => {
             concat!($($tt)*)
+        };
+    }
+
+    #[cfg(anyhow_no_macro_reexport)]
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __anyhow_format {
+        ($($tt:tt)*) => {
+            format!($($tt)*)
         };
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -179,6 +179,6 @@ macro_rules! anyhow {
         }
     });
     ($fmt:expr, $($arg:tt)*) => {
-        $crate::Error::msg(format!($fmt, $($arg)*))
+        $crate::Error::msg($crate::private::format!($fmt, $($arg)*))
     };
 }


### PR DESCRIPTION
This prevents generating nonworking code in the case that the downstream crate contains `#![no_std]` or `#![no_implicit_prelude]`.