### PR TITLE
Use processed format string even on old rust, but as String

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,7 +606,7 @@ pub trait Context<T, E>: context::private::Sealed {
 pub mod private {
     use crate::Error;
     use alloc::fmt;
-    use core::fmt::{Arguments, Debug, Display};
+    use core::fmt::Arguments;
 
     pub use alloc::format;
     pub use core::result::Result::Err;
@@ -621,13 +621,11 @@ pub mod private {
     }
 
     #[doc(hidden)]
+    #[inline]
     #[cold]
-    pub fn format_err<M>(_message: M, args: Arguments) -> Error
-    where
-        M: Display + Debug + Send + Sync + 'static,
-    {
+    pub fn format_err(args: Arguments) -> Error {
         #[cfg(anyhow_no_fmt_arguments_as_str)]
-        let fmt_arguments_as_str = Some(_message);
+        let fmt_arguments_as_str = None::<&str>;
         #[cfg(not(anyhow_no_fmt_arguments_as_str))]
         let fmt_arguments_as_str = args.as_str();
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -168,7 +168,7 @@ macro_rules! ensure {
 #[macro_export]
 macro_rules! anyhow {
     ($msg:literal $(,)?) => ({
-        let error = $crate::private::format_err($msg, $crate::private::format_args!($msg));
+        let error = $crate::private::format_err($crate::private::format_args!($msg));
         error
     });
     ($err:expr $(,)?) => ({


### PR DESCRIPTION
Neither approach is flawless: prior to this commit you'd get `anyhow!("{{")` turned into error message `"{"` on new compilers and `"{{"` on old compilers but both as `&str`; after this commit they'd both be unescaped consistently to `"{"` but on new compilers it's downcastable to `&str` while on old compilers it's `String`. This way is overall less likely to be troublesome but I am open to inverting this back.