### PR TITLE
Drop temporaries as early as possible in $:expr case

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -173,9 +173,10 @@ macro_rules! anyhow {
     });
     ($err:expr $(,)?) => ({
         use $crate::private::kind::*;
-        match $err {
+        let error = match $err {
             error => (&error).anyhow_kind().new(error),
-        }
+        };
+        error
     });
     ($fmt:expr, $($arg:tt)*) => {
         $crate::Error::msg($crate::private::format!($fmt, $($arg)*))

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -10,6 +10,7 @@ mod common;
 
 use self::common::*;
 use anyhow::{anyhow, ensure};
+use std::cell::Cell;
 use std::future;
 
 #[test]
@@ -60,6 +61,14 @@ fn test_temporaries() {
         // semicolon, which is on the other side of the await point, making the
         // enclosing future non-Send.
         future::ready(anyhow!("...")).await;
+    });
+
+    fn message(cell: Cell<&str>) -> &str {
+        cell.get()
+    }
+
+    require_send_sync(async {
+        future::ready(anyhow!(message(Cell::new("...")))).await;
     });
 }
 

--- a/tests/ui/temporary-value.stderr
+++ b/tests/ui/temporary-value.stderr
@@ -2,7 +2,8 @@ error[E0716]: temporary value dropped while borrowed
  --> tests/ui/temporary-value.rs:4:22
   |
 4 |     let _ = anyhow!(&String::new());
-  |             ---------^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+  |             ---------^^^^^^^^^^^^^-
   |             |        |
   |             |        creates a temporary which is freed while still in use
+  |             temporary value is freed at the end of this statement
   |             argument requires that borrow lasts for `'static`


### PR DESCRIPTION
Fixes #186.