### PR TITLE
adding `always_print_causes` feature.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
           toolchain: ${{matrix.rust}}
           components: rust-src
       - run: cargo test
+      - run: cargo test --features always_print_causes
       - run: cargo check --no-default-features
       - run: cargo check --features backtrace
+      - run: cargo check --features always_print_causes
 
   build:
     name: Rust ${{matrix.rust}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["rust-patterns"]
 [features]
 default = ["std"]
 std = []
+always_print_causes = []
 
 [dependencies]
 backtrace = { version = "0.3.51", optional = true }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -4,10 +4,20 @@ use crate::ptr::Ref;
 use core::fmt::{self, Debug, Write};
 
 impl ErrorImpl {
+    #[cfg(feature = "always_print_causes")]
+    fn alternate(_f: &mut fmt::Formatter) -> bool {
+        true
+    }
+
+    #[cfg(not(feature = "always_print_causes"))]
+    fn alternate(f: &mut fmt::Formatter) -> bool {
+        f.alternate()
+    }
+
     pub(crate) unsafe fn display(this: Ref<Self>, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", Self::error(this))?;
 
-        if f.alternate() {
+        if Self::alternate(f) {
             for cause in Self::chain(this).skip(1) {
                 write!(f, ": {}", cause)?;
             }

--- a/tests/test_fmt.rs
+++ b/tests/test_fmt.rs
@@ -66,9 +66,16 @@ Error {
 }\
 ";
 
+#[cfg(not(feature = "always_print_causes"))]
 #[test]
 fn test_display() {
     assert_eq!("g failed", h().unwrap_err().to_string());
+}
+
+#[cfg(feature = "always_print_causes")]
+#[test]
+fn test_display() {
+    assert_eq!("g failed: f failed: oh no!", h().unwrap_err().to_string());
 }
 
 #[test]


### PR DESCRIPTION
adds cargo feature which makes Error always print all causes, effectively turning "{}" into "{:#}"

additional tests may be run via `cargo test --features "always_print_causes"`

motivation for this change is getting full error causes in crosvm without needing to refactor all anyhow::Error prints into using "{:#}" which could be somewhat painful