### PR TITLE
Exclude messages containing whitespace

### DIFF
--- a/src/ensure.rs
+++ b/src/ensure.rs
@@ -47,20 +47,24 @@ impl Buf {
 
 impl Write for Buf {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        let remaining = self.bytes.len() - self.written;
-        if s.len() <= remaining {
-            unsafe {
-                ptr::copy_nonoverlapping(
-                    s.as_ptr(),
-                    self.bytes.as_mut_ptr().add(self.written).cast::<u8>(),
-                    s.len(),
-                );
-            }
-            self.written += s.len();
-            Ok(())
-        } else {
-            Err(fmt::Error)
+        if s.bytes().any(|b| b == b' ' || b == b'\n') {
+            return Err(fmt::Error);
         }
+
+        let remaining = self.bytes.len() - self.written;
+        if s.len() > remaining {
+            return Err(fmt::Error);
+        }
+
+        unsafe {
+            ptr::copy_nonoverlapping(
+                s.as_ptr(),
+                self.bytes.as_mut_ptr().add(self.written).cast::<u8>(),
+                s.len(),
+            );
+        }
+        self.written += s.len();
+        Ok(())
     }
 }
 

--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -367,6 +367,19 @@ fn test_trailer() {
 }
 
 #[test]
+fn test_whitespace() {
+    #[derive(Debug)]
+    pub struct Point {
+        pub x: i32,
+        pub y: i32,
+    }
+
+    let point = Point { x: 0, y: 0 };
+    let test = || Ok(ensure!("" == format!("{:#?}", point)));
+    assert_err(test, "Condition failed: `\"\" == format!(\"{:#?}\", point)` (\"\" vs \"Point {\\n    x: 0,\\n    y: 0,\\n}\")");
+}
+
+#[test]
 fn test_too_long() {
     let test = || Ok(ensure!("" == "x".repeat(10)));
     assert_err(

--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -376,7 +376,7 @@ fn test_whitespace() {
 
     let point = Point { x: 0, y: 0 };
     let test = || Ok(ensure!("" == format!("{:#?}", point)));
-    assert_err(test, "Condition failed: `\"\" == format!(\"{:#?}\", point)` (\"\" vs \"Point {\\n    x: 0,\\n    y: 0,\\n}\")");
+    assert_err(test, "Condition failed: `\"\" == format!(\"{:#?}\", point)`");
 }
 
 #[test]


### PR DESCRIPTION
Our rendering of this error message as ```Condition failed: `$cond` ($lhs vs $rhs)``` is most appropriate for lhs/rhs which are integers, unit variants, or short identifier strings. In the case that they are large objects or elaborate strings, we'll leave it to the programmer to construct a more suitable message manually.