### PR TITLE
Handle parsing unseparated right angle brackets in generics

### DIFF
--- a/src/ensure.rs
+++ b/src/ensure.rs
@@ -319,6 +319,10 @@ macro_rules! __parse_ensure {
         $crate::__parse_ensure!($pop $stack $bail ($($fuel)*) {($($buf)* $rangle) $($parse)*} ($($rest)*) $($rest)*)
     };
 
+    (generic ($pop:ident $stack:tt) $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} $dup:tt >> $($rest:tt)*) => {
+        $crate::__parse_ensure!($pop $stack $bail ($($fuel)*) {($($buf)* >) $($parse)*} (> $($rest)*) > $($rest)*)
+    };
+
     (generic $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} $dup:tt $lit:literal $($rest:tt)*) => {
         $crate::__parse_ensure!(arglist $stack $bail ($($fuel)*) {($($buf)* $lit) $($parse)*} ($($rest)*) $($rest)*)
     };
@@ -339,12 +343,20 @@ macro_rules! __parse_ensure {
         $crate::__parse_ensure!($pop $stack $bail ($($fuel)*) {($($buf)* $ty >) $($parse)*} ($($rest)*) $($rest)*)
     };
 
+    (generic ($pop:ident $stack:tt) $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} $dup:tt $ty:ty >> $($rest:tt)*) => {
+        $crate::__parse_ensure!($pop $stack $bail ($($fuel)*) {($($buf)* $ty >) $($parse)*} (> $($rest)*) > $($rest)*)
+    };
+
     (arglist $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($comma:tt $($dup:tt)*) , $($rest:tt)*) => {
         $crate::__parse_ensure!(generic $stack $bail ($($fuel)*) {($($buf)* $comma) $($parse)*} ($($rest)*) $($rest)*)
     };
 
     (arglist ($pop:ident $stack:tt) $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($rangle:tt $($dup:tt)*) > $($rest:tt)*) => {
         $crate::__parse_ensure!($pop $stack $bail ($($fuel)*) {($($buf)* $rangle) $($parse)*} ($($rest)*) $($rest)*)
+    };
+
+    (arglist ($pop:ident $stack:tt) $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} $dup:tt >> $($rest:tt)*) => {
+        $crate::__parse_ensure!($pop $stack $bail ($($fuel)*) {($($buf)* >) $($parse)*} (> $($rest)*) > $($rest)*)
     };
 
     // high precedence binary operators

--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -2,6 +2,7 @@
     clippy::diverging_sub_expression,
     clippy::if_same_then_else,
     clippy::ifs_same_cond,
+    clippy::items_after_statements,
     clippy::let_and_return,
     clippy::let_underscore_drop,
     clippy::match_bool,

--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -319,6 +319,25 @@ fn test_path() {
         test,
         "Condition failed: `Chain::<'static>::new.t(1) == 2` (1 vs 2)",
     );
+
+    #[derive(PartialOrd, PartialEq, Debug)]
+    enum E<'a, T> {
+        #[allow(dead_code)]
+        T(&'a T),
+        U,
+    }
+
+    #[rustfmt::skip]
+    let test = || Ok(ensure!(E::U::<>>E::U::<u8>));
+    assert_err(test, "Condition failed: `E::U::<> > E::U::<u8>` (U vs U)");
+
+    #[rustfmt::skip]
+    let test = || Ok(ensure!(E::U::<u8>>E::U));
+    assert_err(test, "Condition failed: `E::U::<u8> > E::U` (U vs U)");
+
+    #[rustfmt::skip]
+    let test = || Ok(ensure!(E::U::<u8,>>E::U));
+    assert_err(test, "Condition failed: `E::U::<u8> > E::U` (U vs U)");
 }
 
 #[test]


### PR DESCRIPTION
Rustc parses `S::<>>v` as an expression but it's harder for macro_rules, which have to know that a single incoming `>>` token serves as **both** the generic argument list terminator **and** the comparison operator.