### PR TITLE
Change Backtrace::enabled atomic from SeqCst to Relaxed

### DIFF
--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -182,7 +182,7 @@ mod capture {
     impl Backtrace {
         fn enabled() -> bool {
             static ENABLED: AtomicUsize = AtomicUsize::new(0);
-            match ENABLED.load(Ordering::SeqCst) {
+            match ENABLED.load(Ordering::Relaxed) {
                 0 => {}
                 1 => return false,
                 _ => return true,
@@ -194,7 +194,7 @@ mod capture {
                     None => false,
                 },
             };
-            ENABLED.store(enabled as usize + 1, Ordering::SeqCst);
+            ENABLED.store(enabled as usize + 1, Ordering::Relaxed);
             enabled
         }
 


### PR DESCRIPTION
This mirrors https://github.com/rust-lang/rust/pull/92139. 

The atomic is not synchronizing anything outside of its own value, so we don't need the `Acquire`/`Release` guarantee that all memory operations prior to the store are visible after the subsequent load, nor the `SeqCst` guarantee of all threads seeing all of the sequentially consistent operations in the same order.

Using `Relaxed` reduces the overhead of `Backtrace::capture()` in the case that backtraces are not enabled.