### PR TITLE
Annotate expressions that are rendered poorly by core::stringify

### DIFF
--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -528,7 +528,7 @@ fn test_as() {
     let test = || Ok(ensure!(f as for<'a> fn() as usize * 0 != 0));
     assert_err(
         test,
-        "Condition failed: `f as for<'a>fn() as usize * 0 != 0` (0 vs 0)",
+        "Condition failed: `f as for<'a>fn() as usize * 0 != 0` (0 vs 0)", // FIXME
     );
 
     let test = || Ok(ensure!(f as unsafe fn() as usize * 0 != 0));
@@ -613,7 +613,7 @@ fn test_pat() {
     let test = || Ok(ensure!(if let -1..=1 = 0 { 0 } else { 1 } == 1));
     assert_err(
         test,
-        "Condition failed: `if let -1 ..=1 = 0 { 0 } else { 1 } == 1` (0 vs 1)",
+        "Condition failed: `if let -1 ..=1 = 0 { 0 } else { 1 } == 1` (0 vs 1)", // FIXME
     );
 
     let test = || Ok(ensure!(if let &0 = &0 { 0 } else { 1 } == 1));
@@ -656,7 +656,7 @@ fn test_pat() {
     let test = || Ok(ensure!(if let P::<u8> {} = p { 0 } else { 1 } == 1));
     assert_err(
         test,
-        "Condition failed: `if let P::<u8> {  } = p { 0 } else { 1 } == 1` (0 vs 1)",
+        "Condition failed: `if let P::<u8> {  } = p { 0 } else { 1 } == 1` (0 vs 1)", // FIXME
     );
 
     let test = || Ok(ensure!(if let ::std::marker::PhantomData = p {} != ()));


### PR DESCRIPTION
These are going to need fixes in the rustc pretty printer.