### PR TITLE
Handle negative literal const generic argument after left arrow

### DIFF
--- a/src/ensure.rs
+++ b/src/ensure.rs
@@ -257,6 +257,10 @@ macro_rules! __parse_ensure {
         $crate::__parse_ensure!(generic (epath $stack) $bail ($($fuel)*) {($($buf)* $colons <) $($parse)*} (< $($rest)*) < $($rest)*)
     };
 
+    (epath $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($colons:tt $($dup:tt)*) :: <- $($rest:tt)*) => {
+        $crate::__parse_ensure!(generic (epath $stack) $bail ($($fuel)*) {($($buf)* $colons <) $($parse)*} (- $($rest)*) - $($rest)*)
+    };
+
     (epath $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($colons:tt $($dup:tt)*) :: $ident:ident $($rest:tt)*) => {
         $crate::__parse_ensure!(epath $stack $bail ($($fuel)*) {($($buf)* $colons $ident) $($parse)*} ($($rest)*) $($rest)*)
     };
@@ -301,6 +305,10 @@ macro_rules! __parse_ensure {
 
     (atom $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($dot:tt $ident:tt $colons:tt $($dup:tt)*) . $i:ident :: << $($rest:tt)*) => {
         $crate::__parse_ensure!(generic (atom $stack) $bail ($($fuel)*) {($($buf)* $dot $ident $colons <) $($parse)*} (< $($rest)*) < $($rest)*)
+    };
+
+    (atom $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($dot:tt $ident:tt $colons:tt $($dup:tt)*) . $i:ident :: <- $($rest:tt)*) => {
+        $crate::__parse_ensure!(generic (atom $stack) $bail ($($fuel)*) {($($buf)* $dot $ident $colons <) $($parse)*} (- $($rest)*) - $($rest)*)
     };
 
     (atom $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($dot:tt $($dup:tt)*) . $field:ident $($rest:tt)*) => {
@@ -427,12 +435,20 @@ macro_rules! __parse_ensure {
         $crate::__parse_ensure!(generic (tpath $stack) $bail ($($fuel)*) {($($buf)* <) $($parse)*} (< $($rest)*) < $($rest)*)
     };
 
+    (tpath $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} $dup:tt <- $($rest:tt)*) => {
+        $crate::__parse_ensure!(generic (tpath $stack) $bail ($($fuel)*) {($($buf)* <) $($parse)*} (- $($rest)*) - $($rest)*)
+    };
+
     (tpath $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($colons:tt $langle:tt $($dup:tt)*) :: < $($rest:tt)*) => {
         $crate::__parse_ensure!(generic (tpath $stack) $bail ($($fuel)*) {($($buf)* $colons $langle) $($parse)*} ($($rest)*) $($rest)*)
     };
 
     (tpath $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($colons:tt $($dup:tt)*) :: << $($rest:tt)*) => {
         $crate::__parse_ensure!(generic (tpath $stack) $bail ($($fuel)*) {($($buf)* $colons <) $($parse)*} (< $($rest)*) < $($rest)*)
+    };
+
+    (tpath $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($colons:tt $($dup:tt)*) :: <- $($rest:tt)*) => {
+        $crate::__parse_ensure!(generic (tpath $stack) $bail ($($fuel)*) {($($buf)* $colons <) $($parse)*} (- $($rest)*) - $($rest)*)
     };
 
     (tpath $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($colons:tt $($dup:tt)*) :: $ident:ident $($rest:tt)*) => {

--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -327,10 +327,14 @@ fn test_path() {
     fn f<const I: isize>() {}
     let test = || Ok(ensure!(f::<1>() != ()));
     assert_err(test, "Condition failed: `f::<1>() != ()` (() vs ())");
+    let test = || Ok(ensure!(f::<-1>() != ()));
+    assert_err(test, "Condition failed: `f::<-1>() != ()`"); // FIXME
 
     fn g<T, const I: isize>() {}
     let test = || Ok(ensure!(g::<u8, 1>() != ()));
     assert_err(test, "Condition failed: `g::<u8, 1>() != ()` (() vs ())");
+    let test = || Ok(ensure!(g::<u8, -1>() != ()));
+    assert_err(test, "Condition failed: `g::<u8, -1>() != ()` (() vs ())");
 
     #[derive(PartialOrd, PartialEq, Debug)]
     enum E<'a, T> {

--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -328,7 +328,7 @@ fn test_path() {
     let test = || Ok(ensure!(f::<1>() != ()));
     assert_err(test, "Condition failed: `f::<1>() != ()` (() vs ())");
     let test = || Ok(ensure!(f::<-1>() != ()));
-    assert_err(test, "Condition failed: `f::<-1>() != ()`"); // FIXME
+    assert_err(test, "Condition failed: `f::<-1>() != ()` (() vs ())");
 
     fn g<T, const I: isize>() {}
     let test = || Ok(ensure!(g::<u8, 1>() != ()));


### PR DESCRIPTION
Previously an invocation like `ensure!(f::<-1>() == expected)` was not getting tokenized properly because the <kbd>&lt;-</kbd> in there is really a left arrow token, not <kbd>&lt;</kbd><kbd>-</kbd>, due to silliness in macro_rules.