### PR TITLE
Annotate anyhow::Error as #[must_use]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,7 @@ pub use anyhow as format_err;
 /// }
 /// ```
 #[repr(transparent)]
+#[must_use]
 pub struct Error {
     inner: Own<ErrorImpl>,
 }


### PR DESCRIPTION
This means you get a warning if you use the anyhow! macro instead of the
bail! macro by mistake.