### PR TITLE
Work around RA's RUSTC_WRAPPER poisoning all subsequent command-line builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,6 +65,8 @@ fn main() {
 }
 
 fn compile_probe() -> Option<ExitStatus> {
+    println!("cargo:rerun-if-env-changed=RUSTC_WRAPPER");
+
     let rustc = env::var_os("RUSTC")?;
     let out_dir = env::var_os("OUT_DIR")?;
     let probefile = Path::new(&out_dir).join("probe.rs");


### PR DESCRIPTION
Previously if someone did a build via rust-analyzer, it would run anyhow's build script through rust-analyzer's questionable RUSTC_WRAPPER (#250), and then future `cargo` invocations done on the command line *not* via rust-analyzer would bypass the build script, until `cargo clean` or the `target` dir being deleted.

This PR is an alternative to #251 that tries to isolate command-line `cargo` builds from getting poisoned by rust-analyzer's running of the build script and cargo's caching of the build script output. In contrast to #251, this does not attempt to fix builds done through rust-analyzer, only direct cargo invocations. I still consider rust-analyzer's behavior incorrect so I want to not sweep it under the rug; getting that fixed in rust-analyzer will be between the rust-analyzer devs and its users.