### PR TITLE
Workaround for IntelliJ plugin

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,7 +87,6 @@ fn compile_probe() -> Option<ExitStatus> {
         .arg("--edition=2018")
         .arg("--crate-name=anyhow_build")
         .arg("--crate-type=lib")
-        .arg("--emit=metadata")
         .arg("--out-dir")
         .arg(out_dir)
         .arg(probefile);


### PR DESCRIPTION
For _some_ reason the `intellij-rust-native-helper` (brought in via the RUSTC_WRAPPER env var) used by the rust plugin results in an exit code of 0 from compiling probe.rs, even when running on the stable toolchain, when `--emit=metadata` is set. While to true fix it certainly downstream with the JetBrains folk, it doesn't seem as though the argument is actually required, so may be more expedient to fix here.

The bug manifests itself during workspace syncing with org.rust.cargo.evaluate.build.scripts enabled:
```
error[E0554]: `#![feature]` may not be used on the stable release channel
   --> /Users/wrichard/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.61/src/lib.rs:214:32
    |
214 | #![cfg_attr(backtrace, feature(backtrace))]
    |                                ^^^^^^^^^
```
After removing the argument everything works as expected

System info:
CLion2022.2
cargo 1.62.1-aarch64-apple-darwin
Rust plugin 0.4.175.4772-222