### PR TITLE
Rename &mut Demand arguments to 'demand'

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,8 +34,8 @@ const PROBE: &str = r#"
     }
 
     impl Error for E {
-        fn provide<'a>(&'a self, req: &mut Demand<'a>) {
-            req.provide_ref(&self.backtrace);
+        fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+            demand.provide_ref(&self.backtrace);
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -128,8 +128,8 @@ where
     }
 
     #[cfg(backtrace)]
-    fn provide<'a>(&'a self, req: &mut Demand<'a>) {
-        self.error.provide(req);
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        self.error.provide(demand);
     }
 }
 
@@ -142,9 +142,9 @@ where
     }
 
     #[cfg(backtrace)]
-    fn provide<'a>(&'a self, req: &mut Demand<'a>) {
-        req.provide_ref(self.error.backtrace());
-        self.error.provide(req);
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        demand.provide_ref(self.error.backtrace());
+        self.error.provide(demand);
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -896,11 +896,11 @@ impl ErrorImpl {
     }
 
     #[cfg(backtrace)]
-    unsafe fn provide<'a>(this: Ref<'a, Self>, req: &mut Demand<'a>) {
+    unsafe fn provide<'a>(this: Ref<'a, Self>, demand: &mut Demand<'a>) {
         if let Some(backtrace) = &this.deref().backtrace {
-            req.provide_ref(backtrace);
+            demand.provide_ref(backtrace);
         }
-        Self::error(this).provide(req);
+        Self::error(this).provide(demand);
     }
 
     #[cold]
@@ -918,8 +918,8 @@ where
     }
 
     #[cfg(backtrace)]
-    fn provide<'a>(&'a self, req: &mut Demand<'a>) {
-        unsafe { ErrorImpl::provide(self.erase(), req) }
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        unsafe { ErrorImpl::provide(self.erase(), demand) }
     }
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -75,7 +75,7 @@ impl StdError for BoxedError {
     }
 
     #[cfg(backtrace)]
-    fn provide<'a>(&'a self, req: &mut Demand<'a>) {
-        self.0.provide(req);
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        self.0.provide(demand);
     }
 }


### PR DESCRIPTION
This was changed in the Error trait by https://github.com/rust-lang/rust/pull/100955.