### PR TITLE
impl std::any::Provider for anyhow::Error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ compile_error! {
 const PROBE: &str = r#"
     #![feature(error_generic_member_access, provide_any)]
 
-    use std::any::Demand;
+    use std::any::{Demand, Provider};
     use std::backtrace::{Backtrace, BacktraceStatus};
     use std::error::Error;
     use std::fmt::{self, Display};
@@ -37,6 +37,12 @@ const PROBE: &str = r#"
         fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
             demand.provide_ref(&self.backtrace);
         }
+    }
+
+    struct P;
+
+    impl Provider for P {
+        fn provide<'a>(&'a self, _demand: &mut Demand<'a>) {}
     }
 
     const _: fn() = || {

--- a/src/error.rs
+++ b/src/error.rs
@@ -522,15 +522,16 @@ impl Error {
             Some(addr.cast::<E>().deref_mut())
         }
     }
+}
 
+#[cfg(backtrace)]
+impl std::any::Provider for Error {
     // Called by thiserror when you have `#[source] anyhow::Error`. This provide
     // implementation includes the anyhow::Error's Backtrace if any, unlike
     // deref'ing to dyn Error where the provide implementation would include
     // only the original error's Backtrace from before it got wrapped into an
     // anyhow::Error.
-    #[cfg(backtrace)]
-    #[doc(hidden)]
-    pub fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         unsafe { ErrorImpl::provide(self.inner.by_ref(), demand) }
     }
 }


### PR DESCRIPTION
This is required in https://github.com/dtolnay/thiserror/blob/2ca76edd6eada9522e1198355a83bc16049f52b0/tests/test_backtrace.rs#L140-L144 following https://github.com/dtolnay/thiserror/pull/190.