### PR TITLE
Remove 2 frames of noise from 'context' backtraces

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -47,7 +47,12 @@ where
     where
         C: Display + Send + Sync + 'static,
     {
-        self.map_err(|error| error.ext_context(context))
+        // Not using map_err to save 2 useless frames off the captured backtrace
+        // in ext_context.
+        match self {
+            Ok(ok) => Ok(ok),
+            Err(error) => Err(error.ext_context(context)),
+        }
     }
 
     fn with_context<C, F>(self, context: F) -> Result<T, Error>
@@ -55,7 +60,10 @@ where
         C: Display + Send + Sync + 'static,
         F: FnOnce() -> C,
     {
-        self.map_err(|error| error.ext_context(context()))
+        match self {
+            Ok(ok) => Ok(ok),
+            Err(error) => Err(error.ext_context(context())),
+        }
     }
 }
 


### PR DESCRIPTION
Repro:

```rust
use anyhow::Context;

fn main() -> anyhow::Result<()> {
    let result = Err(std::fmt::Error);
    result.context("...")
}
```

Before:

```console
0: <E as anyhow::context::ext::StdError>::ext_context
          at /git/anyhow/src/context.rs:27:29
1: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::context::{{closure}}
          at /git/anyhow/src/context.rs:50:30
2: core::result::Result<T,E>::map_err
          at /rustc/4b8f4319954ff2642690b9e5cbe4af352d095bf6/library/core/src/result.rs:861:27
3: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::context
          at /git/anyhow/src/context.rs:50:9
4: testing::main
          at ./src/main.rs:5:5
```

After:

```console
0: <E as anyhow::context::ext::StdError>::ext_context
          at /git/anyhow/src/context.rs:27:29
1: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::context
          at /git/anyhow/src/context.rs:52:31
2: testing::main
          at ./src/main.rs:5:5
```