### PR TITLE
Remove 2 frames of backtrace noise on Option's Context impl

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -92,7 +92,12 @@ impl<T> Context<T, Infallible> for Option<T> {
     where
         C: Display + Send + Sync + 'static,
     {
-        self.ok_or_else(|| Error::from_display(context, backtrace!()))
+        // Not using ok_or_else to save 2 useless frames off the captured
+        // backtrace.
+        match self {
+            Some(ok) => Ok(ok),
+            None => Err(Error::from_display(context, backtrace!())),
+        }
     }
 
     fn with_context<C, F>(self, context: F) -> Result<T, Error>
@@ -100,7 +105,10 @@ impl<T> Context<T, Infallible> for Option<T> {
         C: Display + Send + Sync + 'static,
         F: FnOnce() -> C,
     {
-        self.ok_or_else(|| Error::from_display(context(), backtrace!()))
+        match self {
+            Some(ok) => Ok(ok),
+            None => Err(Error::from_display(context(), backtrace!())),
+        }
     }
 }
 


### PR DESCRIPTION
Another instance of the same issue as #279, which I missed in that PR...

Repro:

```rust
use anyhow::Context;

fn main() -> anyhow::Result<()> {
    let result = None::<()>;
    result.context("...")
}
```

Before:

```console
0: anyhow::context::<impl anyhow::Context<T,core::convert::Infallible> for core::option::Option<T>>::context::{{closure}}
          at /git/anyhow/src/context.rs:95:57
1: core::option::Option<T>::ok_or_else
          at /rustc/4b8f4319954ff2642690b9e5cbe4af352d095bf6/library/core/src/option.rs:1083:25
2: anyhow::context::<impl anyhow::Context<T,core::convert::Infallible> for core::option::Option<T>>::context
          at /git/anyhow/src/context.rs:95:9
3: testing::main
          at ./src/main.rs:5:5
```

After:

```console
0: anyhow::context::<impl anyhow::Context<T,core::convert::Infallible> for core::option::Option<T>>::context
          at /git/anyhow/src/context.rs:99:54
1: testing::main
          at ./src/main.rs:5:5
```