### PR TITLE
Remove redundant Backtrace provide_ref from ContextError

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -159,7 +159,6 @@ where
 
     #[cfg(backtrace)]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        demand.provide_ref(self.error.backtrace());
         self.error.provide(demand);
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,7 @@ use core::convert::Infallible;
 use core::fmt::{self, Debug, Display, Write};
 
 #[cfg(backtrace)]
-use std::any::Demand;
+use std::any::{Demand, Provider};
 
 mod ext {
     use super::*;
@@ -159,7 +159,7 @@ where
 
     #[cfg(backtrace)]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        self.error.provide(demand);
+        Provider::provide(&self.error, demand);
     }
 }
 


### PR DESCRIPTION
Back when this line was added in 46d3d2c9f5260e74b0ff4c6262713f51b843e9de, it was necessary in order for the following program to successfully obtain the requested backtrace:

```rust
#![feature(error_generic_member_access)]

use anyhow::anyhow;
use std::backtrace::Backtrace;

fn main() {
    let error = anyhow!("...").context("...");
    (&*error).request_ref::<Backtrace>().unwrap();
}
```

However #268 made it redundant, as now `self.error.provide(demand)` has become a call to:

https://github.com/dtolnay/anyhow/blob/cccc7852ff8937f1c65c7e14e6080630f18e4c85/src/error.rs#L534-L536

which calls:

https://github.com/dtolnay/anyhow/blob/cccc7852ff8937f1c65c7e14e6080630f18e4c85/src/error.rs#L911-L916