### PR TITLE
Update backtrace documentation for Rust 1.65 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ anyhow = "1.0"
   }
   ```
 
-- If using the nightly channel, or stable with `features = ["backtrace"]`, a
-  backtrace is captured and printed with the error if the underlying error type
-  does not already provide its own. In order to see backtraces, they must be
-  enabled through the environment variables described in [`std::backtrace`]:
+- If using Rust 1.65 or above, or an older version with
+  `features = ["backtrace"]`, a backtrace is captured and printed with the 
+  error if the underlying error type does not already provide its own. In order 
+  to see backtraces, they must be enabled through the environment variables
+  described in [`std::backtrace`]:
 
   - If you want panics and errors to both have backtraces, set
     `RUST_BACKTRACE=1`;
@@ -86,10 +87,7 @@ anyhow = "1.0"
   - If you want only panics to have backtraces, set `RUST_BACKTRACE=1` and
     `RUST_LIB_BACKTRACE=0`.
 
-  The tracking issue for this feature is [rust-lang/rust#53487].
-
   [`std::backtrace`]: https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
-  [rust-lang/rust#53487]: https://github.com/rust-lang/rust/issues/53487
 
 - Anyhow works with any error type that has an impl of `std::error::Error`,
   including ones defined in your crate. We do not bundle a `derive(Error)` macro

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,11 +128,11 @@
 //!   # ;
 //!   ```
 //!
-//! - If using the nightly channel, or stable with `features = ["backtrace"]`, a
-//!   backtrace is captured and printed with the error if the underlying error
-//!   type does not already provide its own. In order to see backtraces, they
-//!   must be enabled through the environment variables described in
-//!   [`std::backtrace`]:
+//! - If using Rust 1.65 or above, or an older version with
+//!   `features = ["backtrace"]`, a backtrace is captured and printed with the
+//!   error if the underlying error type does not already provide its own. In order
+//!   to see backtraces, they must be enabled through the environment variables
+//!   described in [`std::backtrace`]:
 //!
 //!   - If you want panics and errors to both have backtraces, set
 //!     `RUST_BACKTRACE=1`;
@@ -140,10 +140,7 @@
 //!   - If you want only panics to have backtraces, set `RUST_BACKTRACE=1` and
 //!     `RUST_LIB_BACKTRACE=0`.
 //!
-//!   The tracking issue for this feature is [rust-lang/rust#53487].
-//!
 //!   [`std::backtrace`]: https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
-//!   [rust-lang/rust#53487]: https://github.com/rust-lang/rust/issues/53487
 //!
 //! - Anyhow works with any error type that has an impl of `std::error::Error`,
 //!   including ones defined in your crate. We do not bundle a `derive(Error)`


### PR DESCRIPTION
[Rust 1.65 stabilizes the backtrace API which previously required nightly](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#stabilized-apis), this PR updates the documentation accordingly

[I've tested this and the backtrace does work without the `backtrace` feature on 1.65.](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=aea0fe7e668c6c49da8e06f687ae39e6) (Make sure to enable backtrace in the Playground)