### PR TITLE
Feature: track caller

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.39"
 [features]
 default = ["std"]
 std = []
+track_caller = []
 
 [dependencies]
 backtrace = { version = "0.3.51", optional = true }

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -35,6 +35,20 @@ macro_rules! backtrace {
     };
 }
 
+#[cfg(feature = "track_caller")]
+macro_rules! caller {
+    () => {
+        Some(core::panic::Location::caller())
+    }
+}
+
+#[cfg(not(feature = "track_caller"))]
+macro_rules! caller {
+    () => {
+        None
+    }
+}
+
 #[cfg(backtrace)]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -25,11 +25,12 @@ mod ext {
             C: Display + Send + Sync + 'static,
         {
             let backtrace = backtrace_if_absent!(&self);
-            Error::from_context(context, self, backtrace)
+            Error::from_context(context, self, backtrace, caller!())
         }
     }
 
     impl StdError for Error {
+        #[cfg_attr(feature = "track_caller", track_caller)]
         fn ext_context<C>(self, context: C) -> Error
         where
             C: Display + Send + Sync + 'static,
@@ -43,6 +44,7 @@ impl<T, E> Context<T, E> for Result<T, E>
 where
     E: ext::StdError + Send + Sync + 'static,
 {
+    #[cfg_attr(feature = "track_caller", track_caller)]
     fn context<C>(self, context: C) -> Result<T, Error>
     where
         C: Display + Send + Sync + 'static,
@@ -55,6 +57,7 @@ where
         }
     }
 
+    #[cfg_attr(feature = "track_caller", track_caller)]
     fn with_context<C, F>(self, context: F) -> Result<T, Error>
     where
         C: Display + Send + Sync + 'static,
@@ -88,6 +91,7 @@ where
 /// }
 /// ```
 impl<T> Context<T, Infallible> for Option<T> {
+    #[cfg_attr(feature = "track_caller", track_caller)]
     fn context<C>(self, context: C) -> Result<T, Error>
     where
         C: Display + Send + Sync + 'static,
@@ -96,10 +100,11 @@ impl<T> Context<T, Infallible> for Option<T> {
         // backtrace.
         match self {
             Some(ok) => Ok(ok),
-            None => Err(Error::from_display(context, backtrace!())),
+            None => Err(Error::from_display(context, backtrace!(), caller!())),
         }
     }
 
+    #[cfg_attr(feature = "track_caller", track_caller)]
     fn with_context<C, F>(self, context: F) -> Result<T, Error>
     where
         C: Display + Send + Sync + 'static,
@@ -107,7 +112,7 @@ impl<T> Context<T, Infallible> for Option<T> {
     {
         match self {
             Some(ok) => Ok(ok),
-            None => Err(Error::from_display(context(), backtrace!())),
+            None => Err(Error::from_display(context(), backtrace!(), caller!())),
         }
     }
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -24,6 +24,9 @@ impl ErrorImpl {
         }
 
         write!(f, "{}", error)?;
+        if let Some(location) = Self::caller(this) {
+            writeln!(f, "\n  at {}:{}", location.file(), location.line())?;
+        }
 
         if let Some(cause) = error.source() {
             write!(f, "\n\nCaused by:")?;

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -67,7 +67,7 @@ impl Adhoc {
     where
         M: Display + Debug + Send + Sync + 'static,
     {
-        Error::from_adhoc(message, backtrace!())
+        Error::from_adhoc(message, backtrace!(), caller!())
     }
 }
 
@@ -111,6 +111,6 @@ impl Boxed {
     #[cold]
     pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
         let backtrace = backtrace_if_absent!(&*error);
-        Error::from_boxed(error, backtrace)
+        Error::from_boxed(error, backtrace, caller!())
     }
 }


### PR DESCRIPTION
This PR tries to add caller tracking with a new feature, "track_caller". This will allow, if set, to track the caller of any call of `context` or `with_context` and print it in the errors output.

## Current State

MWE:
```rust
use anyhow::Result;
use anyhow::Context;

fn main() -> Result<()> {
    None
        .context("A")
        .context("B")
        .with_context(|| format!("{}", "C"))?
}
```

Output:
```
Error: C
  at src/main.rs:8


Caused by:
    0: B
    1: A
```

## TODO

The PR isn't complete yet. It's still missing the ability to access the stored caller `Location` information in the call to `fmt::debug`. However, I do not know how to turn a `&dyn Error` into a `Ref<ImplError>` for this purpose. Does anyone have advice for me, please?

Related to #139 