### PR TITLE
Enable backtrace support for >= 1.65 stable compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ anyhow = "1.0"
   }
   ```
 
-- If using the nightly channel, or stable with `features = ["backtrace"]`, a
-  backtrace is captured and printed with the error if the underlying error type
-  does not already provide its own. In order to see backtraces, they must be
-  enabled through the environment variables described in [`std::backtrace`]:
+- If using Rust ≥ 1.65 or `features = ["backtrace"]`, a backtrace is captured
+  and printed with the error if the underlying error type does not already
+  provide its own. In order to see backtraces, they must be enabled through the
+  environment variables described in [`std::backtrace`]:
 
   - If you want panics and errors to both have backtraces, set
     `RUST_BACKTRACE=1`;
@@ -86,10 +86,7 @@ anyhow = "1.0"
   - If you want only panics to have backtraces, set `RUST_BACKTRACE=1` and
     `RUST_LIB_BACKTRACE=0`.
 
-  The tracking issue for this feature is [rust-lang/rust#53487].
-
   [`std::backtrace`]: https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
-  [rust-lang/rust#53487]: https://github.com/rust-lang/rust/issues/53487
 
 - Anyhow works with any error type that has an impl of `std::error::Error`,
   including ones defined in your crate. We do not bundle a `derive(Error)` macro

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -35,7 +35,7 @@ macro_rules! backtrace {
     };
 }
 
-#[cfg(backtrace)]
+#[cfg(provide_api)]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {
         match ($err as &dyn std::error::Error).request_ref::<std::backtrace::Backtrace>() {
@@ -45,7 +45,7 @@ macro_rules! backtrace_if_absent {
     };
 }
 
-#[cfg(all(feature = "std", not(backtrace), feature = "backtrace"))]
+#[cfg(all(feature = "std", not(provide_api), any(backtrace, feature = "backtrace")))]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {
         backtrace!()

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use crate::{Context, Error, StdError};
 use core::convert::Infallible;
 use core::fmt::{self, Debug, Display, Write};
 
-#[cfg(backtrace)]
+#[cfg(provide_api)]
 use std::any::{Demand, Provider};
 
 mod ext {
@@ -143,7 +143,7 @@ where
         Some(&self.error)
     }
 
-    #[cfg(backtrace)]
+    #[cfg(provide_api)]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         StdError::provide(&self.error, demand);
     }
@@ -157,7 +157,7 @@ where
         Some(unsafe { crate::ErrorImpl::error(self.error.inner.by_ref()) })
     }
 
-    #[cfg(backtrace)]
+    #[cfg(provide_api)]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         Provider::provide(&self.error, demand);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,11 +128,10 @@
 //!   # ;
 //!   ```
 //!
-//! - If using the nightly channel, or stable with `features = ["backtrace"]`, a
-//!   backtrace is captured and printed with the error if the underlying error
-//!   type does not already provide its own. In order to see backtraces, they
-//!   must be enabled through the environment variables described in
-//!   [`std::backtrace`]:
+//! - If using Rust ≥ 1.65 or `features = ["backtrace"]`, a backtrace is captured
+//!   and printed with the error if the underlying error type does not already
+//!   provide its own. In order to see backtraces, they must be enabled through the
+//!   environment variables described in [`std::backtrace`]:
 //!
 //!   - If you want panics and errors to both have backtraces, set
 //!     `RUST_BACKTRACE=1`;
@@ -140,10 +139,7 @@
 //!   - If you want only panics to have backtraces, set `RUST_BACKTRACE=1` and
 //!     `RUST_LIB_BACKTRACE=0`.
 //!
-//!   The tracking issue for this feature is [rust-lang/rust#53487].
-//!
 //!   [`std::backtrace`]: https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
-//!   [rust-lang/rust#53487]: https://github.com/rust-lang/rust/issues/53487
 //!
 //! - Anyhow works with any error type that has an impl of `std::error::Error`,
 //!   including ones defined in your crate. We do not bundle a `derive(Error)`
@@ -211,7 +207,7 @@
 //! non-Anyhow error type inside a function that returns Anyhow's error type.
 
 #![doc(html_root_url = "https://docs.rs/anyhow/1.0.68")]
-#![cfg_attr(backtrace, feature(error_generic_member_access, provide_any))]
+#![cfg_attr(provide_api, feature(error_generic_member_access, provide_any))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(dead_code, unused_imports, unused_mut)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,7 +1,7 @@
 use crate::StdError;
 use core::fmt::{self, Debug, Display};
 
-#[cfg(backtrace)]
+#[cfg(provide_api)]
 use std::any::Demand;
 
 #[repr(transparent)]
@@ -74,7 +74,7 @@ impl StdError for BoxedError {
         self.0.source()
     }
 
-    #[cfg(backtrace)]
+    #[cfg(provide_api)]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         self.0.provide(demand);
     }


### PR DESCRIPTION
Fixes #284 

The `std::backtrace` APIs relevant for this crate were stabilized in 1.65. This commit makes anyhow use those API if possible. `std::backtrace` is preferred over the `backtrace` crate, so for 1.65+ compilers, enabling the `backtrace` crate feature does nothing essentially (except downloading the dependency, so don't do that).

Previously, when a nightly compiler was used, use of `std::backtrace` as well as the Provider API was enabled. This PR separates those two APIs such that `std::backtrace` is used for nightly OR 1.65+ stable compilers; and the Provider API is used for nightly compilers only.

---

I tested this for 1.64, 1.65, the current stable and the current nightly. For all, `cargo test` and `cargo test --features=backtrace` runs fine. I also wanted to test for older nightlies (which do not support the various APIs yet) but I couldn't get it to work as dependencies did not compile. It seems like everyone seems to only support the latest nightly. Which makes sense. So I assumed I could do the same here.

This also means that in my doc changes I simply say "for Rust >= 1.65" and don't mention nightly anymore, as that's "implied" if only the latest nightly is supported anyway.

I am not sure if this is the best approach. There are lots of options how to fix #284 I think. I like my approach as it results in a fairly small diff, does not bump the MSRV to 1.65, and still works for nightly (also enabling the `provide` API then). But I'm curious if you'd like this to use a different approach.
