### PR TITLE
Hide repr attribute from documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ pub use anyhow as format_err;
 ///     # Ok(())
 /// }
 /// ```
-#[repr(transparent)]
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct Error {
     inner: Own<ErrorImpl>,
 }


### PR DESCRIPTION
Work around this rustdoc issue: https://github.com/rust-lang/rust/issues/90435.