### PR TITLE
Support const block syntax in ensure! macro

### DIFF
--- a/src/ensure.rs
+++ b/src/ensure.rs
@@ -231,6 +231,11 @@ macro_rules! __parse_ensure {
         $crate::__parse_ensure!(atom $stack $bail ($($fuel)*) {($($buf)* $unsafe $block) $($parse)*} ($($rest)*) $($rest)*)
     };
 
+    (0 $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} ($const:tt $block:tt $($dup:tt)*) const {$($body:tt)*} $($rest:tt)*) => {
+        // TODO: this is mostly useless due to https://github.com/rust-lang/rust/issues/86730
+        $crate::__parse_ensure!(atom $stack $bail ($($fuel)*) {($($buf)* $const $block) $($parse)*} ($($rest)*) $($rest)*)
+    };
+
     (0 $stack:tt $bail:tt (~$($fuel:tt)*) {($($buf:tt)*) $($parse:tt)*} $dup:tt $lit:literal $($rest:tt)*) => {
         $crate::__parse_ensure!(atom $stack $bail ($($fuel)*) {($($buf)* $lit) $($parse)*} ($($rest)*) $($rest)*)
     };


### PR DESCRIPTION
This is mostly useless due to https://github.com/rust-lang/rust/issues/86730 (i.e. `ensure!(1 == const { 2 })` still won't work) but it's good to have a case here to revisit in the future.