### PR TITLE
Add support for wasm_bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ rust-version = "1.39"
 [features]
 default = ["std"]
 std = []
+wasm_bindgen = ["std", "wasm-bindgen"]
 
 [dependencies]
 backtrace = { version = "0.3.51", optional = true }
+wasm-bindgen = {version = "0.2.84", optional = true, features = ["std"], default-features = false}
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ type inside a function that returns Anyhow's error type.
 
 <br>
 
+## wasm_bindgen support
+
+To use `anyhow::Error` in functions exported to JavaScript, you need to enable the `wasm_bindgen` feature.
+
+<br>
+
 ## Comparison to failure
 
 The `anyhow::Error` type works something like `failure::Error`, but unlike

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ use core::mem::ManuallyDrop;
 #[cfg(not(anyhow_no_ptr_addr_of))]
 use core::ptr;
 use core::ptr::NonNull;
+#[cfg(feature = "wasm_bindgen")]
+use wasm_bindgen::JsValue;
 
 #[cfg(feature = "std")]
 use core::ops::{Deref, DerefMut};
@@ -988,5 +990,12 @@ impl AsRef<dyn StdError + Send + Sync> for Error {
 impl AsRef<dyn StdError> for Error {
     fn as_ref(&self) -> &(dyn StdError + 'static) {
         &**self
+    }
+}
+
+#[cfg(feature = "wasm_bindgen")]
+impl Into<JsValue> for Error {
+    fn into(self) -> JsValue {
+        JsValue::from_str(self.to_string().as_str())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,12 @@
 //! `std::error::Error` trait which is only available through std, no_std mode
 //! will require an explicit `.map_err(Error::msg)` when working with a
 //! non-Anyhow error type inside a function that returns Anyhow's error type.
+//!
+//! <br>
+//!
+//! ## wasm_bindgen support
+//!
+//! To use `anyhow::Error` in functions exported to JavaScript, you need to enable the `wasm_bindgen` feature.
 
 #![doc(html_root_url = "https://docs.rs/anyhow/1.0.70")]
 #![cfg_attr(backtrace, feature(error_generic_member_access, provide_any))]


### PR DESCRIPTION
Implement `Into<JsValue>` to `anyhow::Error` on an optional feature, allow it to be use in functions exported to js.

Fix #115 