### PR TITLE
Mark format_err macro as doc(no_inline)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,7 @@ trait StdError: Debug + Display {
     }
 }
 
+#[doc(no_inline)]
 pub use anyhow as format_err;
 
 /// The `Error` type, a wrapper around a dynamic error type.


### PR DESCRIPTION
It seems rustdoc in Rust version 1.67.0 changed how it renders this macro.

`cargo +1.66.0 doc`:

![Screenshot from 2023-04-29 12-14-02](https://user-images.githubusercontent.com/1940490/235320404-8d234ccf-4bff-412f-a18c-aa5bb5264755.png)

`cargo +1.67.0 doc`:

![Screenshot from 2023-04-29 12-13-56](https://user-images.githubusercontent.com/1940490/235320408-253c50c0-83a3-47ef-9613-ed664424ef52.png)

The same difference is visible in the documentation rendered by docs.rs:

- https://docs.rs/anyhow/1.0.66/anyhow/index.html#reexports
- https://docs.rs/anyhow/1.0.67/anyhow/index.html#macros

(The resemblance between those version numbers is a coincidence.)

This PR restores the older rendering.