### PR TITLE
IntoError trait

### DIFF
--- a/src/into_error.rs
+++ b/src/into_error.rs
@@ -1,0 +1,65 @@
+/// Convert an error into `anyhow::Error`.
+///
+/// Trait can be used when another error type is used, and transparent conversion
+/// from both standard error types and from `anyhow::Error` is needed.
+///
+/// # Example
+///
+/// ```
+/// struct MyError(anyhow::Error);
+///
+/// impl<E: anyhow::IntoError> From<E> for MyError {
+///    fn from(value: E) -> Self {
+///       MyError(value.into_error())
+///    }
+/// }
+///
+/// impl From<MyError> for anyhow::Error {
+///     fn from(value: MyError) -> Self {
+///         value.0
+///     }
+/// }
+///
+/// fn returns_anyhow_result() -> anyhow::Result<()> {
+/// # Ok(())
+/// }
+///
+/// fn returns_io_result() -> std::io::Result<()> {
+/// # Ok(())
+/// }
+///
+/// fn returns_my_result() -> Result<(), MyError> {
+/// # Ok(())
+/// }
+///
+/// fn foo() -> Result<(), MyError> {
+///     returns_anyhow_result()?;
+///     returns_io_result()?;
+///     returns_my_result()?;
+///     Ok(())
+/// }
+///
+/// fn bar() -> anyhow::Result<()> {
+///    foo()?;
+///    Ok(())
+/// }
+/// ```
+pub trait IntoError {
+    /// Convert an error into `anyhow::Error`.
+    fn into_error(self) -> crate::Error;
+}
+
+impl IntoError for crate::Error {
+    #[inline]
+    fn into_error(self) -> crate::Error {
+        self
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: std::error::Error + Send + Sync + 'static> IntoError for E {
+    #[inline]
+    fn into_error(self) -> crate::Error {
+        crate::Error::new(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ mod context;
 mod ensure;
 mod error;
 mod fmt;
+mod into_error;
 mod kind;
 mod macros;
 mod ptr;
@@ -268,6 +269,8 @@ trait StdError: Debug + Display {
 
 #[doc(no_inline)]
 pub use anyhow as format_err;
+
+pub use into_error::IntoError;
 
 /// The `Error` type, a wrapper around a dynamic error type.
 ///

--- a/tests/test_into_error.rs
+++ b/tests/test_into_error.rs
@@ -1,0 +1,36 @@
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct SharedError(Arc<anyhow::Error>);
+
+impl<E: anyhow::IntoError> From<E> for SharedError {
+    fn from(value: E) -> Self {
+        SharedError(Arc::new(value.into_error()))
+    }
+}
+
+impl From<SharedError> for anyhow::Error {
+    fn from(value: SharedError) -> Self {
+        #[derive(Debug)]
+        struct SharedErrorAsError(SharedError);
+
+        impl Display for SharedErrorAsError {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                Display::fmt(&self.0 .0, f)
+            }
+        }
+        impl std::error::Error for SharedErrorAsError {}
+
+        anyhow::Error::new(SharedErrorAsError(value))
+    }
+}
+
+#[test]
+fn test_into_error() {
+    let e1 = SharedError::from(anyhow::anyhow!("test"));
+    let e2 = SharedError::from(io::Error::new(io::ErrorKind::Other, "test"));
+    let _e1: anyhow::Error = anyhow::Error::from(e1);
+    let _e2: anyhow::Error = anyhow::Error::from(e2);
+}


### PR DESCRIPTION
Consider this scenario. There's another error type which should be constructable from either standard errors or `anyhow::Error`. So `?` operator can be used to return results with new error type.

Example of such error is `SharedError` from buck2 project:

https://github.com/facebook/buck2/blob/126049599e9d1b56c25c5fba7e6127294719dff0/app/buck2_common/src/result.rs#L46

It is not possible to implement such generic conversion in Rust.

For example, this approach is compilation error:

```
impl<E: Into<anyhow::Error>> From<E> for SharedError {
    fn from(err: E) -> Self { ... }
}

   = note: conflicting implementation in crate `core`:
           - impl<T> From<T> for T;
```

This approach is different compilation error:

```
impl<E: std::error::Error> From<E> for SharedError {
    fn from(err: E) -> Self { ...  }
}

impl From<anyhow::Error> for SharedError {
    fn from(err: anyhow::Error) -> Self { ... }
}

   = note: upstream crates may add a new impl of trait `std::error::Error` for type `anyhow::Error` in future versions
```

`IntoError` crate implemented inside `anyhow` crate allows implementation:

```
impl<E: anyhow::IntoError> From<E> for SharedError {
    fn from(value: E) -> Self { ... }
}
```