### PR TITLE
Cargo.toml add backtrace to features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.39"
 [features]
 default = ["std"]
 std = ["backtrace/std"]
-backtrace = ["std"]
 
 [dependencies]
 backtrace = { version = "0.3.51", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ rust-version = "1.39"
 
 [features]
 default = ["std"]
-std = []
+std = ["backtrace/std"]
+backtrace = ["std"]
 
 [dependencies]
 backtrace = { version = "0.3.51", optional = true }


### PR DESCRIPTION
`backtrace` was added to features (so it's visible on Crates.io, in versions). And also added all feature dependencies. So `backtrace` will automatically enable `std`, and `std` will enable `backtrace/std` feature (just in case if someday backtrace crate will remove `std` from the default features).

Also `cargo check --no-default-features --features backtrace` is working now. Maybe remove message:
```rust
#[cfg(all(feature = "backtrace", not(feature = "std")))]
compile_error! {
    "`backtrace` feature without `std` feature is not supported"
}
```
from [build.rs](https://github.com/dtolnay/anyhow/blob/2c913b30787418f9f9d615a9c8de006ef5bff739/build.rs#L9)?