### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,10 @@ fn main() {
         // core::fmt::Arguments::as_str
         // https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html#stabilized-apis
         println!("cargo:rustc-cfg=anyhow_no_fmt_arguments_as_str");
+
+        // #![deny(unsafe_op_in_unsafe_fn)]
+        // https://github.com/rust-lang/rust/issues/71668
+        println!("cargo:rustc-cfg=anyhow_no_unsafe_op_in_unsafe_fn_lint");
     }
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -5,10 +5,11 @@ use core::fmt::{self, Debug, Write};
 
 impl ErrorImpl {
     pub(crate) unsafe fn display(this: Ref<Self>, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", Self::error(this))?;
+        write!(f, "{}", unsafe { Self::error(this) })?;
 
         if f.alternate() {
-            for cause in Self::chain(this).skip(1) {
+            let chain = unsafe { Self::chain(this) };
+            for cause in chain.skip(1) {
                 write!(f, ": {}", cause)?;
             }
         }
@@ -17,7 +18,7 @@ impl ErrorImpl {
     }
 
     pub(crate) unsafe fn debug(this: Ref<Self>, f: &mut fmt::Formatter) -> fmt::Result {
-        let error = Self::error(this);
+        let error = unsafe { Self::error(this) };
 
         if f.alternate() {
             return Debug::fmt(error, f);
@@ -43,7 +44,7 @@ impl ErrorImpl {
         {
             use crate::backtrace::BacktraceStatus;
 
-            let backtrace = Self::backtrace(this);
+            let backtrace = unsafe { Self::backtrace(this) };
             if let BacktraceStatus::Captured = backtrace.status() {
                 let mut backtrace = backtrace.to_string();
                 write!(f, "\n\n")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,11 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(dead_code, unused_imports, unused_mut)]
+#![cfg_attr(
+    not(anyhow_no_unsafe_op_in_unsafe_fn_lint),
+    deny(unsafe_op_in_unsafe_fn)
+)]
+#![cfg_attr(anyhow_no_unsafe_op_in_unsafe_fn_lint, allow(unused_unsafe))]
 #![allow(
     clippy::doc_markdown,
     clippy::enum_glob_use,

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -42,7 +42,7 @@ where
     }
 
     pub unsafe fn boxed(self) -> Box<T> {
-        Box::from_raw(self.ptr.as_ptr())
+        unsafe { Box::from_raw(self.ptr.as_ptr()) }
     }
 
     pub fn by_ref(&self) -> Ref<T> {
@@ -120,7 +120,7 @@ where
     }
 
     pub unsafe fn deref(self) -> &'a T {
-        &*self.ptr.as_ptr()
+        unsafe { &*self.ptr.as_ptr() }
     }
 }
 
@@ -179,13 +179,13 @@ where
     }
 
     pub unsafe fn deref_mut(self) -> &'a mut T {
-        &mut *self.ptr.as_ptr()
+        unsafe { &mut *self.ptr.as_ptr() }
     }
 }
 
 impl<'a, T> Mut<'a, T> {
     pub unsafe fn read(self) -> T {
-        self.ptr.as_ptr().read()
+        unsafe { self.ptr.as_ptr().read() }
     }
 }
 


### PR DESCRIPTION
This lint is allow-by-default for now in 2021 edition, but is going to become warn-by-default in 2024 edition.