### PR TITLE
Rerun build script on RUSTC_BOOTSTRAP change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -47,6 +47,8 @@ const PROBE: &str = r#"
 
 fn main() {
     if cfg!(feature = "std") {
+        println!("cargo:rerun-if-env-changed=RUSTC_BOOTSTRAP");
+
         match compile_probe() {
             Some(status) if status.success() => println!("cargo:rustc-cfg=backtrace"),
             _ => {}


### PR DESCRIPTION
Equivalent of https://github.com/dtolnay/thiserror/pull/269.

Example failure mode without this PR:

```rust
pub fn repro(e: &anyhow::Error) -> &std::backtrace::Backtrace {
    e.backtrace()
}
```

```console
$ cargo +stable check  #(expected failure)
   Compiling anyhow v1.0.76
    Checking repro v0.0.0
error[E0599]: no method named `backtrace` found for reference `&anyhow::Error` in the current scope
 --> src/lib.rs:2:7
  |
2 |     e.backtrace()
  |       ^^^^^^^^^ method not found in `&Error`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `repro` due to previous error
```

```console
$ RUSTC_BOOTSTRAP=1 cargo +stable check  #(should work, but doesn't)
    Checking repro v0.0.0
error[E0599]: no method named `backtrace` found for reference `&anyhow::Error` in the current scope
 --> src/lib.rs:2:7
  |
2 |     e.backtrace()
  |       ^^^^^^^^^ method not found in `&Error`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `repro` due to previous error
```

```console
$ cargo +stable clean
     Removed 30 files, 9.9MiB total
$ RUSTC_BOOTSTRAP=1 cargo +stable check
   Compiling anyhow v1.0.76
    Checking repro v0.0.0
    Finished dev [unoptimized + debuginfo] target(s) in 0.59s
```

After this PR: `RUSTC_BOOTSTRAP=1 cargo +stable check` works the first time.