### PR TITLE
Separate cfgs for Backtrace vs Error::provide

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -50,7 +50,10 @@ fn main() {
         println!("cargo:rerun-if-env-changed=RUSTC_BOOTSTRAP");
 
         match compile_probe() {
-            Some(status) if status.success() => println!("cargo:rustc-cfg=backtrace"),
+            Some(status) if status.success() => {
+                println!("cargo:rustc-cfg=backtrace");
+                println!("cargo:rustc-cfg=error_generic_member_access");
+            }
             _ => {}
         }
     }

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -35,7 +35,7 @@ macro_rules! backtrace {
     };
 }
 
-#[cfg(backtrace)]
+#[cfg(error_generic_member_access)]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {
         match std::error::request_ref::<std::backtrace::Backtrace>($err as &dyn std::error::Error) {
@@ -45,7 +45,11 @@ macro_rules! backtrace_if_absent {
     };
 }
 
-#[cfg(all(feature = "std", not(backtrace), feature = "backtrace"))]
+#[cfg(all(
+    feature = "std",
+    not(error_generic_member_access),
+    any(backtrace, feature = "backtrace")
+))]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {
         backtrace!()

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use crate::{Context, Error, StdError};
 use core::convert::Infallible;
 use core::fmt::{self, Debug, Display, Write};
 
-#[cfg(backtrace)]
+#[cfg(error_generic_member_access)]
 use std::error::Request;
 
 mod ext {
@@ -143,7 +143,7 @@ where
         Some(&self.error)
     }
 
-    #[cfg(backtrace)]
+    #[cfg(error_generic_member_access)]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {
         StdError::provide(&self.error, request);
     }
@@ -157,7 +157,7 @@ where
         Some(unsafe { crate::ErrorImpl::error(self.error.inner.by_ref()) })
     }
 
-    #[cfg(backtrace)]
+    #[cfg(error_generic_member_access)]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {
         Error::provide(&self.error, request);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@
 //! non-Anyhow error type inside a function that returns Anyhow's error type.
 
 #![doc(html_root_url = "https://docs.rs/anyhow/1.0.76")]
-#![cfg_attr(backtrace, feature(error_generic_member_access))]
+#![cfg_attr(error_generic_member_access, feature(error_generic_member_access))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(dead_code, unused_imports, unused_mut)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,7 +1,7 @@
 use crate::StdError;
 use core::fmt::{self, Debug, Display};
 
-#[cfg(backtrace)]
+#[cfg(error_generic_member_access)]
 use std::error::Request;
 
 #[repr(transparent)]
@@ -74,7 +74,7 @@ impl StdError for BoxedError {
         self.0.source()
     }
 
-    #[cfg(backtrace)]
+    #[cfg(error_generic_member_access)]
     fn provide<'a>(&'a self, request: &mut Request<'a>) {
         self.0.provide(request);
     }


### PR DESCRIPTION
For now it's always the case that either both or neither of these cfgs is set, but with this PR, it becomes possible to set `cfg(backtrace)` without setting `cfg(error_generic_member_access)`.