### PR TITLE
Rename `cfg(backtrace)` -> `cfg(std_backtrace)`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,7 +51,7 @@ fn main() {
 
         match compile_probe() {
             Some(status) if status.success() => {
-                println!("cargo:rustc-cfg=backtrace");
+                println!("cargo:rustc-cfg=std_backtrace");
                 println!("cargo:rustc-cfg=error_generic_member_access");
             }
             _ => {}

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,34 +1,34 @@
-#[cfg(backtrace)]
+#[cfg(std_backtrace)]
 pub(crate) use std::backtrace::{Backtrace, BacktraceStatus};
 
-#[cfg(all(not(backtrace), feature = "backtrace"))]
+#[cfg(all(not(std_backtrace), feature = "backtrace"))]
 pub(crate) use self::capture::{Backtrace, BacktraceStatus};
 
-#[cfg(not(any(backtrace, feature = "backtrace")))]
+#[cfg(not(any(std_backtrace, feature = "backtrace")))]
 pub(crate) enum Backtrace {}
 
-#[cfg(backtrace)]
+#[cfg(std_backtrace)]
 macro_rules! impl_backtrace {
     () => {
         std::backtrace::Backtrace
     };
 }
 
-#[cfg(all(not(backtrace), feature = "backtrace"))]
+#[cfg(all(not(std_backtrace), feature = "backtrace"))]
 macro_rules! impl_backtrace {
     () => {
         impl core::fmt::Debug + core::fmt::Display
     };
 }
 
-#[cfg(any(backtrace, feature = "backtrace"))]
+#[cfg(any(std_backtrace, feature = "backtrace"))]
 macro_rules! backtrace {
     () => {
         Some(crate::backtrace::Backtrace::capture())
     };
 }
 
-#[cfg(not(any(backtrace, feature = "backtrace")))]
+#[cfg(not(any(std_backtrace, feature = "backtrace")))]
 macro_rules! backtrace {
     () => {
         None
@@ -48,7 +48,7 @@ macro_rules! backtrace_if_absent {
 #[cfg(all(
     feature = "std",
     not(error_generic_member_access),
-    any(backtrace, feature = "backtrace")
+    any(std_backtrace, feature = "backtrace")
 ))]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {
@@ -56,14 +56,14 @@ macro_rules! backtrace_if_absent {
     };
 }
 
-#[cfg(all(feature = "std", not(backtrace), not(feature = "backtrace")))]
+#[cfg(all(feature = "std", not(std_backtrace), not(feature = "backtrace")))]
 macro_rules! backtrace_if_absent {
     ($err:expr) => {
         None
     };
 }
 
-#[cfg(all(not(backtrace), feature = "backtrace"))]
+#[cfg(all(not(std_backtrace), feature = "backtrace"))]
 mod capture {
     use backtrace::{BacktraceFmt, BytesOrWideString, Frame, PrintFmt, SymbolName};
     use core::cell::UnsafeCell;

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,7 +101,7 @@ impl Error {
             object_drop_rest: object_drop_front::<E>,
             #[cfg(all(
                 not(error_generic_member_access),
-                any(backtrace, feature = "backtrace")
+                any(std_backtrace, feature = "backtrace")
             ))]
             object_backtrace: no_backtrace,
         };
@@ -129,7 +129,7 @@ impl Error {
             object_drop_rest: object_drop_front::<M>,
             #[cfg(all(
                 not(error_generic_member_access),
-                any(backtrace, feature = "backtrace")
+                any(std_backtrace, feature = "backtrace")
             ))]
             object_backtrace: no_backtrace,
         };
@@ -158,7 +158,7 @@ impl Error {
             object_drop_rest: object_drop_front::<M>,
             #[cfg(all(
                 not(error_generic_member_access),
-                any(backtrace, feature = "backtrace")
+                any(std_backtrace, feature = "backtrace")
             ))]
             object_backtrace: no_backtrace,
         };
@@ -189,7 +189,7 @@ impl Error {
             object_drop_rest: context_drop_rest::<C, E>,
             #[cfg(all(
                 not(error_generic_member_access),
-                any(backtrace, feature = "backtrace")
+                any(std_backtrace, feature = "backtrace")
             ))]
             object_backtrace: no_backtrace,
         };
@@ -218,7 +218,7 @@ impl Error {
             object_drop_rest: object_drop_front::<Box<dyn StdError + Send + Sync>>,
             #[cfg(all(
                 not(error_generic_member_access),
-                any(backtrace, feature = "backtrace")
+                any(std_backtrace, feature = "backtrace")
             ))]
             object_backtrace: no_backtrace,
         };
@@ -334,7 +334,7 @@ impl Error {
             object_drop_rest: context_chain_drop_rest::<C>,
             #[cfg(all(
                 not(error_generic_member_access),
-                any(backtrace, feature = "backtrace")
+                any(std_backtrace, feature = "backtrace")
             ))]
             object_backtrace: context_backtrace::<C>,
         };
@@ -376,7 +376,7 @@ impl Error {
     /// ```
     ///
     /// [tracking]: https://github.com/rust-lang/rust/issues/53487
-    #[cfg(any(backtrace, feature = "backtrace"))]
+    #[cfg(any(std_backtrace, feature = "backtrace"))]
     #[cfg_attr(doc_cfg, doc(cfg(any(nightly, feature = "backtrace"))))]
     pub fn backtrace(&self) -> &impl_backtrace!() {
         unsafe { ErrorImpl::backtrace(self.inner.by_ref()) }
@@ -622,7 +622,7 @@ struct ErrorVTable {
     object_drop_rest: unsafe fn(Own<ErrorImpl>, TypeId),
     #[cfg(all(
         not(error_generic_member_access),
-        any(backtrace, feature = "backtrace")
+        any(std_backtrace, feature = "backtrace")
     ))]
     object_backtrace: unsafe fn(Ref<ErrorImpl>) -> Option<&Backtrace>,
 }
@@ -730,7 +730,7 @@ where
 
 #[cfg(all(
     not(error_generic_member_access),
-    any(backtrace, feature = "backtrace")
+    any(std_backtrace, feature = "backtrace")
 ))]
 fn no_backtrace(e: Ref<ErrorImpl>) -> Option<&Backtrace> {
     let _ = e;
@@ -854,7 +854,7 @@ where
 // Safety: requires layout of *e to match ErrorImpl<ContextError<C, Error>>.
 #[cfg(all(
     not(error_generic_member_access),
-    any(backtrace, feature = "backtrace")
+    any(std_backtrace, feature = "backtrace")
 ))]
 #[allow(clippy::unnecessary_wraps)]
 unsafe fn context_backtrace<C>(e: Ref<ErrorImpl>) -> Option<&Backtrace>
@@ -926,7 +926,7 @@ impl ErrorImpl {
         return unsafe { (vtable(this.ptr).object_mut)(this) };
     }
 
-    #[cfg(any(backtrace, feature = "backtrace"))]
+    #[cfg(any(std_backtrace, feature = "backtrace"))]
     pub(crate) unsafe fn backtrace(this: Ref<Self>) -> &Backtrace {
         // This unwrap can only panic if the underlying error's backtrace method
         // is nondeterministic, which would only happen in maliciously

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -40,7 +40,7 @@ impl ErrorImpl {
             }
         }
 
-        #[cfg(any(backtrace, feature = "backtrace"))]
+        #[cfg(any(std_backtrace, feature = "backtrace"))]
         {
             use crate::backtrace::BacktraceStatus;
 

--- a/tests/test_fmt.rs
+++ b/tests/test_fmt.rs
@@ -79,7 +79,7 @@ fn test_altdisplay() {
 }
 
 #[test]
-#[cfg_attr(not(backtrace), ignore)]
+#[cfg_attr(not(std_backtrace), ignore)]
 fn test_debug() {
     assert_eq!(EXPECTED_DEBUG_F, format!("{:?}", f().unwrap_err()));
     assert_eq!(EXPECTED_DEBUG_G, format!("{:?}", g().unwrap_err()));


### PR DESCRIPTION
The rustc-cfg turned on via the build script refers specifically to std::backtrace. Separately there is `cfg(feature = "backtrace")` which refers to the conditional dependency on the `backtrace` crate.