### PR TITLE
Remove option_if_let_else clippy suppression from build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::option_if_let_else)]
-
 use std::env;
 use std::ffi::OsString;
 use std::path::Path;


### PR DESCRIPTION
This lint got downgraded from `pedantic` to `nursery` by https://github.com/rust-lang/rust-clippy/pull/7568 so we no longer run it.