### PR TITLE
Include env-dep:RUSTC_BOOTSTRAP in dep-info for sccache

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -121,7 +121,7 @@ fn compile_probe(rustc_bootstrap: bool) -> bool {
         .arg("--edition=2018")
         .arg("--crate-name=anyhow")
         .arg("--crate-type=lib")
-        .arg("--emit=metadata")
+        .arg("--emit=dep-info,metadata")
         .arg("--out-dir")
         .arg(out_dir)
         .arg(probefile);

--- a/build/probe.rs
+++ b/build/probe.rs
@@ -30,3 +30,6 @@ impl Error for MyError {
 }
 
 const _: fn(&dyn Error) -> Option<&Backtrace> = |err| error::request_ref::<Backtrace>(err);
+
+// Include in sccache cache key.
+const _: Option<&str> = option_env!("RUSTC_BOOTSTRAP");


### PR DESCRIPTION
Copying over a fix from https://github.com/dtolnay/thiserror/pull/279 + https://github.com/dtolnay/thiserror/pull/280.