### PR TITLE
Work around needless_return rust-analyzer bug in bail macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,15 +54,18 @@
 /// ```
 #[macro_export]
 macro_rules! bail {
-    ($msg:literal $(,)?) => {
+    ($msg:literal $(,)?) => {{
+        #[allow(clippy::needless_return)]
         return $crate::__private::Err($crate::__anyhow!($msg))
-    };
-    ($err:expr $(,)?) => {
+    }};
+    ($err:expr $(,)?) => {{
+        #[allow(clippy::needless_return)]
         return $crate::__private::Err($crate::__anyhow!($err))
-    };
-    ($fmt:expr, $($arg:tt)*) => {
+    }};
+    ($fmt:expr, $($arg:tt)*) => {{
+        #[allow(clippy::needless_return)]
         return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*))
-    };
+    }};
 }
 
 /// Return early with an error if a condition is not satisfied.


### PR DESCRIPTION
I confirmed that this does **not** fix the rust-analyzer issue reported in https://github.com/dtolnay/anyhow/issues/351. It will need to be fixed in rust-analyzer.

Without rust-analyzer, `cargo clippy` correctly does not report a needless_return lint in this code.