### PR TITLE
Rely on docs.rs to define --cfg=docsrs by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ doc-scrape-examples = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,6 @@ fn main() {
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_fmt_arguments_as_str)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_ptr_addr_of)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_unsafe_op_in_unsafe_fn_lint)");
-        println!("cargo:rustc-check-cfg=cfg(doc_cfg)");
         println!("cargo:rustc-check-cfg=cfg(error_generic_member_access)");
         println!("cargo:rustc-check-cfg=cfg(std_backtrace)");
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,7 @@ impl Error {
     /// If the error type does not provide a backtrace, a backtrace will be
     /// created here to ensure that a backtrace exists.
     #[cfg(feature = "std")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     #[cold]
     #[must_use]
     pub fn new<E>(error: E) -> Self
@@ -400,7 +400,7 @@ impl Error {
     /// }
     /// ```
     #[cfg(feature = "std")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     #[cold]
     pub fn chain(&self) -> Chain {
         unsafe { ErrorImpl::chain(self.inner.by_ref()) }
@@ -412,7 +412,7 @@ impl Error {
     /// The root cause is the last error in the iterator produced by
     /// [`chain()`][Error::chain].
     #[cfg(feature = "std")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn root_cause(&self) -> &(dyn StdError + 'static) {
         self.chain().last().unwrap()
     }
@@ -555,7 +555,7 @@ impl Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<E> From<E> for Error
 where
     E: StdError + Send + Sync + 'static,
@@ -568,7 +568,7 @@ where
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Deref for Error {
     type Target = dyn StdError + Send + Sync + 'static;
 
@@ -578,7 +578,7 @@ impl Deref for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl DerefMut for Error {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { ErrorImpl::error_mut(self.inner.by_mut()) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@
 
 #![doc(html_root_url = "https://docs.rs/anyhow/1.0.85")]
 #![cfg_attr(error_generic_member_access, feature(error_generic_member_access))]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 #![deny(dead_code, unused_imports, unused_mut)]
 #![cfg_attr(
@@ -408,7 +408,7 @@ pub struct Error {
 /// }
 /// ```
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Clone)]
 pub struct Chain<'a> {
     state: crate::chain::ChainState<'a>,


### PR DESCRIPTION
As of recently, docs.rs defines a `docsrs` configuration for all builds, so we no longer need to do it using our own `package.metadata.docs.rs.rustdoc-args`.