### PR TITLE
Enable {:?} test regardless of backtrace support

### DIFF
--- a/tests/test_fmt.rs
+++ b/tests/test_fmt.rs
@@ -79,7 +79,6 @@ fn test_altdisplay() {
 }
 
 #[test]
-#[cfg_attr(not(std_backtrace), ignore)]
 fn test_debug() {
     assert_eq!(EXPECTED_DEBUG_F, format!("{:?}", f().unwrap_err()));
     assert_eq!(EXPECTED_DEBUG_G, format!("{:?}", g().unwrap_err()));


### PR DESCRIPTION
This cfg hasn't been needed since https://github.com/dtolnay/anyhow/commit/645a81c1357f5ecd389f9fab4fdc5383dbd369b3.