### PR TITLE
Remove note about `?` in no_std mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,11 +200,6 @@
 //! [dependencies]
 //! anyhow = { version = "1.0", default-features = false }
 //! ```
-//!
-//! Since the `?`-based error conversions would normally rely on the
-//! `std::error::Error` trait which is only available through std, no_std mode
-//! will require an explicit `.map_err(Error::msg)` when working with a
-//! non-Anyhow error type inside a function that returns Anyhow's error type.
 
 #![doc(html_root_url = "https://docs.rs/anyhow/1.0.87")]
 #![cfg_attr(error_generic_member_access, feature(error_generic_member_access))]


### PR DESCRIPTION
`core::error` was stabilized in 1.81
https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#coreerrorerror

[playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=f8bff2ba52d452964535619da5c2b1a5)