### PR TITLE
Ensure UnwindSafe even with "backtrace" feature enabled and old Rust

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,7 @@ fn main() {
     if rustc >= 80 {
         println!("cargo:rustc-check-cfg=cfg(anyhow_nightly_testing)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_core_error)");
+        println!("cargo:rustc-check-cfg=cfg(anyhow_no_core_unwind_safe)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_fmt_arguments_as_str)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_ptr_addr_of)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_unsafe_op_in_unsafe_fn_lint)");
@@ -89,6 +90,12 @@ fn main() {
         // #![deny(unsafe_op_in_unsafe_fn)]
         // https://github.com/rust-lang/rust/issues/71668
         println!("cargo:rustc-cfg=anyhow_no_unsafe_op_in_unsafe_fn_lint");
+    }
+
+    if rustc < 56 {
+        // core::panic::{UnwindSafe, RefUnwindSafe}
+        // https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#stabilized-apis
+        println!("cargo:rustc-cfg=anyhow_no_core_unwind_safe");
     }
 
     if !error_generic_member_access && cfg!(feature = "std") && rustc >= 65 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,9 +12,13 @@ use core::fmt::{self, Debug, Display};
 use core::mem::ManuallyDrop;
 #[cfg(any(feature = "std", not(anyhow_no_core_error)))]
 use core::ops::{Deref, DerefMut};
+#[cfg(not(anyhow_no_core_unwind_safe))]
+use core::panic::{RefUnwindSafe, UnwindSafe};
 #[cfg(not(anyhow_no_ptr_addr_of))]
 use core::ptr;
 use core::ptr::NonNull;
+#[cfg(all(feature = "std", anyhow_no_core_unwind_safe))]
+use std::panic::{RefUnwindSafe, UnwindSafe};
 
 impl Error {
     /// Create a new error object from any error type.
@@ -1015,3 +1019,9 @@ impl AsRef<dyn StdError> for Error {
         &**self
     }
 }
+
+#[cfg(any(feature = "std", not(anyhow_no_core_unwind_safe)))]
+impl UnwindSafe for Error {}
+
+#[cfg(any(feature = "std", not(anyhow_no_core_unwind_safe)))]
+impl RefUnwindSafe for Error {}


### PR DESCRIPTION
On Rust version 1.72 and older, this code didn't used to compile:

```rust
// [dependencies]
// anyhow = { version = "1", features = ["backtrace"] }

fn main() {
    let err = anyhow::Error::msg("...");
    let _ = std::panic::catch_unwind(move || err);
}
```

```console
error[E0277]: the type `UnsafeCell<backtrace::Capture>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> src/main.rs:6:38
    |
6   |     let _ = std::panic::catch_unwind(move || err);
    |             ------------------------ ^^^^^^^^^^^ `UnsafeCell<backtrace::Capture>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |             |
    |             required by a bound introduced by this call
    |
    = help: within `anyhow::error::ErrorImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<backtrace::Capture>`
note: required because it appears within the type `LazilyResolvedCapture`
   --> ~/.rustup/toolchains/1.72-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/backtrace.rs:433:8
    |
433 | struct LazilyResolvedCapture {
    |        ^^^^^^^^^^^^^^^^^^^^^
note: required because it appears within the type `Inner`
   --> ~/.rustup/toolchains/1.72-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/backtrace.rs:133:6
    |
133 | enum Inner {
    |      ^^^^^
note: required because it appears within the type `Backtrace`
   --> ~/.rustup/toolchains/1.72-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/backtrace.rs:109:12
    |
109 | pub struct Backtrace {
    |            ^^^^^^^^^
note: required because it appears within the type `Option<Backtrace>`
   --> ~/.rustup/toolchains/1.72-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:563:10
    |
563 | pub enum Option<T> {
    |          ^^^^^^
note: required because it appears within the type `ErrorImpl`
   --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.88/src/error.rs:863:19
    |
863 | pub(crate) struct ErrorImpl<E = ()> {
    |                   ^^^^^^^^^
    = note: required for `NonNull<anyhow::error::ErrorImpl>` to implement `UnwindSafe`
note: required because it appears within the type `Own<ErrorImpl>`
   --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.88/src/ptr.rs:6:12
    |
6   | pub struct Own<T>
    |            ^^^
note: required because it appears within the type `Error`
   --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.88/src/lib.rs:389:12
    |
389 | pub struct Error {
    |            ^^^^^
note: required because it's used within this closure
   --> src/main.rs:6:38
    |
6   |     let _ = std::panic::catch_unwind(move || err);
    |                                      ^^^^^^^
note: required by a bound in `catch_unwind`
   --> ~/.rustup/toolchains/1.72-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:141:40
    |
141 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
```