### PR TITLE
A convenience macro to unwrap an option with a general message

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -240,3 +240,32 @@ macro_rules! __anyhow {
         $crate::Error::msg($crate::__private::format!($fmt, $($arg)*))
     };
 }
+
+/// Unwraps an option with a general error message.
+///
+/// This macro is equivalent to ``maybe_foo.context("`maybe_foo` is `None`)?;``
+///
+/// The surrounding function's or closure's return value is required to be
+/// <code>Result&lt;_, [anyhow::Error][crate::Error]&gt;</code>.
+///
+/// ## Example
+/// ```
+/// # use anyhow::unwrap_some;
+///
+/// # fn main() -> anyhow::Result<()> {
+///     let maybe_foo: Option<i32> = Some(42);
+///     let foo = unwrap_some!(maybe_foo);
+///     assert_eq!(foo, 42);
+///
+///     let maybe_foo: Option<i32> = None;
+///     let result: anyhow::Result<_> = (|| Ok(unwrap_some!(maybe_foo)))();
+///     assert_eq!(result.unwrap_err().to_string(), "`maybe_foo` is `None`");
+/// #
+/// #    Ok(())
+/// # }
+#[macro_export]
+macro_rules! unwrap_some {
+    ($opt:expr) => {
+        $opt.ok_or_else(|| $crate::anyhow!(concat!("`", stringify!($opt), "`", " is `None`")))?
+    };
+}

--- a/tests/test_unwrap_some.rs
+++ b/tests/test_unwrap_some.rs
@@ -1,0 +1,20 @@
+use anyhow::unwrap_some;
+
+#[test]
+fn test_some() -> anyhow::Result<()> {
+    let maybe_foo: Option<i32> = Some(42);
+    let foo = unwrap_some!(maybe_foo);
+    assert_eq!(foo, 42);
+    Ok(())
+}
+
+#[test]
+fn test_none() {
+    struct Foo {
+        maybe: Option<i32>,
+    }
+
+    let foo = Foo { maybe: None };
+    let result: anyhow::Result<_> = (|| Ok(unwrap_some!(foo.maybe)))();
+    assert_eq!(result.unwrap_err().to_string(), "`foo.maybe` is `None`");
+}


### PR DESCRIPTION
```rust
let foo = unwrap_some!(maybe_foo);

/// Instead of
let foo = maybe_foo.context("`maybe_foo` is `None`")?;
```

Some APIs, e.g. `aws_sdk`, assume extensive unwrapping of options. This macro is meant to avoid the repetition of variable names in context messages.

I'm not sure about the naming. Other options are:

- `ensure_some` - but it seems inconsistent with the ensure! macro, which doesn't return anything
- `unwrap_opt`
- `unwrap_option`