### PR TITLE
Align naming between Ok function argument and its documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,8 +646,8 @@ pub trait Context<T, E>: context::private::Sealed {
 ///    |         consider giving this pattern the explicit type `std::result::Result<i32, E>`, where the type parameter `E` is specified
 /// ```
 #[allow(non_snake_case)]
-pub fn Ok<T>(t: T) -> Result<T> {
-    Result::Ok(t)
+pub fn Ok<T>(value: T) -> Result<T> {
+    Result::Ok(value)
 }
 
 // Not public API. Referenced by macro-generated code.


### PR DESCRIPTION
The documentation users `Ok::<_, anyhow::Error>(value)` referring to the argument name "value".