### PR TITLE
Add `construct_` prefix to name of private construct functions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -25,7 +25,7 @@ mod ext {
             C: Display + Send + Sync + 'static,
         {
             let backtrace = backtrace_if_absent!(&self);
-            Error::from_context(context, self, backtrace)
+            Error::construct_from_context(context, self, backtrace)
         }
     }
 
@@ -96,7 +96,7 @@ impl<T> Context<T, Infallible> for Option<T> {
         // backtrace.
         match self {
             Some(ok) => Ok(ok),
-            None => Err(Error::from_display(context, backtrace!())),
+            None => Err(Error::construct_from_display(context, backtrace!())),
         }
     }
 
@@ -107,7 +107,7 @@ impl<T> Context<T, Infallible> for Option<T> {
     {
         match self {
             Some(ok) => Ok(ok),
-            None => Err(Error::from_display(context(), backtrace!())),
+            None => Err(Error::construct_from_display(context(), backtrace!())),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ impl Error {
         E: StdError + Send + Sync + 'static,
     {
         let backtrace = backtrace_if_absent!(&error);
-        Error::from_std(error, backtrace)
+        Error::construct_from_std(error, backtrace)
     }
 
     /// Create a new error object from a printable error message.
@@ -82,12 +82,12 @@ impl Error {
     where
         M: Display + Debug + Send + Sync + 'static,
     {
-        Error::from_adhoc(message, backtrace!())
+        Error::construct_from_adhoc(message, backtrace!())
     }
 
     #[cfg(any(feature = "std", not(anyhow_no_core_error)))]
     #[cold]
-    pub(crate) fn from_std<E>(error: E, backtrace: Option<Backtrace>) -> Self
+    pub(crate) fn construct_from_std<E>(error: E, backtrace: Option<Backtrace>) -> Self
     where
         E: StdError + Send + Sync + 'static,
     {
@@ -113,7 +113,7 @@ impl Error {
     }
 
     #[cold]
-    pub(crate) fn from_adhoc<M>(message: M, backtrace: Option<Backtrace>) -> Self
+    pub(crate) fn construct_from_adhoc<M>(message: M, backtrace: Option<Backtrace>) -> Self
     where
         M: Display + Debug + Send + Sync + 'static,
     {
@@ -142,7 +142,7 @@ impl Error {
     }
 
     #[cold]
-    pub(crate) fn from_display<M>(message: M, backtrace: Option<Backtrace>) -> Self
+    pub(crate) fn construct_from_display<M>(message: M, backtrace: Option<Backtrace>) -> Self
     where
         M: Display + Send + Sync + 'static,
     {
@@ -172,7 +172,11 @@ impl Error {
 
     #[cfg(any(feature = "std", not(anyhow_no_core_error)))]
     #[cold]
-    pub(crate) fn from_context<C, E>(context: C, error: E, backtrace: Option<Backtrace>) -> Self
+    pub(crate) fn construct_from_context<C, E>(
+        context: C,
+        error: E,
+        backtrace: Option<Backtrace>,
+    ) -> Self
     where
         C: Display + Send + Sync + 'static,
         E: StdError + Send + Sync + 'static,
@@ -202,7 +206,7 @@ impl Error {
 
     #[cfg(any(feature = "std", not(anyhow_no_core_error)))]
     #[cold]
-    pub(crate) fn from_boxed(
+    pub(crate) fn construct_from_boxed(
         error: Box<dyn StdError + Send + Sync>,
         backtrace: Option<Backtrace>,
     ) -> Self {
@@ -562,7 +566,7 @@ where
     #[cold]
     fn from(error: E) -> Self {
         let backtrace = backtrace_if_absent!(&error);
-        Error::from_std(error, backtrace)
+        Error::construct_from_std(error, backtrace)
     }
 }
 

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -70,7 +70,7 @@ impl Adhoc {
     where
         M: Display + Debug + Send + Sync + 'static,
     {
-        Error::from_adhoc(message, backtrace!())
+        Error::construct_from_adhoc(message, backtrace!())
     }
 }
 
@@ -116,6 +116,6 @@ impl Boxed {
     #[cold]
     pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
         let backtrace = backtrace_if_absent!(&*error);
-        Error::from_boxed(error, backtrace)
+        Error::construct_from_boxed(error, backtrace)
     }
 }


### PR DESCRIPTION
This frees up `from_boxed` for the name of a public function.