### PR TITLE
Ignore missing_abi lint in nightly-2025-01-16

### DIFF
--- a/tests/test_ensure.rs
+++ b/tests/test_ensure.rs
@@ -614,6 +614,7 @@ fn test_as() {
 
     extern "C" fn extern_fn() {}
     #[rustfmt::skip]
+    #[allow(missing_abi)]
     let test = || Ok(ensure!(extern_fn as extern fn() as usize * 0 != 0));
     assert_err(
         test,


### PR DESCRIPTION
```console
warning: extern declarations without an explicit ABI are deprecated
   --> tests/test_ensure.rs:617:43
    |
617 |     let test = || Ok(ensure!(extern_fn as extern fn() as usize * 0 != 0));
    |                                           ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
    |
    = note: `#[warn(missing_abi)]` on by default
```

This test is specifically for testing that our parser is able to parse extern function pointer types both with and without abi, so it will continue to be useful to keep this written without abi.