### PR TITLE
Allow boxed stderrors created from anyhow::Error to be downcast to the original type.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -739,9 +739,10 @@ unsafe fn object_boxed<E>(e: Own<ErrorImpl>) -> Box<dyn StdError + Send + Sync +
 where
     E: StdError + Send + Sync + 'static,
 {
-    // Attach ErrorImpl<E>'s native StdError vtable. The StdError impl is below.
+    // Attach E's native StdError vtable. We don't use ErrorImpl<E>'s vtable as that would prevent
+    // downcasting to E.
     let unerased_own = e.cast::<ErrorImpl<E>>();
-    unsafe { unerased_own.boxed() }
+    Box::new(unsafe { unerased_own.boxed() }._object)
 }
 
 // Safety: requires layout of *e to match ErrorImpl<E>.

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -43,3 +43,13 @@ fn test_boxed_anyhow() {
     let error = anyhow!(error);
     assert_eq!("oh no!", error.source().unwrap().to_string());
 }
+
+#[test]
+fn test_into_boxed_downcasts() {
+    let error = MyError {
+        source: io::ErrorKind::NotFound.into(),
+    };
+    let error = anyhow::Error::from(error);
+    let error: Box<dyn StdError + 'static> = error.into();
+    error.downcast_ref::<MyError>().expect("should be original");
+}


### PR DESCRIPTION
Closes #379.