### PR TITLE
Mark macros with clippy::format_args

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,6 +70,7 @@ fn main() {
     if rustc >= 80 {
         println!("cargo:rustc-check-cfg=cfg(anyhow_build_probe)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_nightly_testing)");
+        println!("cargo:rustc-check-cfg=cfg(anyhow_no_clippy_format_args)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_core_error)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_core_unwind_safe)");
         println!("cargo:rustc-check-cfg=cfg(anyhow_no_fmt_arguments_as_str)");
@@ -111,6 +112,12 @@ fn main() {
         // core::error::Error
         // https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#coreerrorerror
         println!("cargo:rustc-cfg=anyhow_no_core_error");
+    }
+
+    if rustc < 85 {
+        // #[clippy::format_args]
+        // https://doc.rust-lang.org/1.85.1/clippy/attribs.html#clippyformat_args
+        println!("cargo:rustc-cfg=anyhow_no_clippy_format_args");
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,6 +54,7 @@
 /// # }
 /// ```
 #[macro_export]
+#[cfg_attr(not(anyhow_no_clippy_format_args), clippy::format_args)]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
         return $crate::__private::Err($crate::__anyhow!($msg))
@@ -154,6 +155,7 @@ __ensure![
 #[cfg(not(doc))]
 __ensure![
     #[macro_export]
+    #[cfg_attr(not(anyhow_no_clippy_format_args), clippy::format_args)]
     macro_rules! ensure {
         ($($tt:tt)*) => {
             $crate::__parse_ensure!(
@@ -198,6 +200,7 @@ __ensure![
 /// }
 /// ```
 #[macro_export]
+#[cfg_attr(not(anyhow_no_clippy_format_args), clippy::format_args)]
 macro_rules! anyhow {
     ($msg:literal $(,)?) => {
         $crate::__private::must_use({


### PR DESCRIPTION
Closes #408.

Example lint:

```console
warning: `format!` in `bail!` args
 --> src/main.rs:5:5
  |
5 |     bail!("{}", format!("something failed at {}", Location::caller()));
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: combine the `format!(..)` arguments with the outer `bail!(..)` call
  = help: or consider changing `format!` to `format_args!`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_in_format_args
  = note: `#[warn(clippy::format_in_format_args)]` on by default
```