### PR TITLE
feat: support serializing the error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ repository = "https://github.com/dtolnay/anyhow"
 rust-version = "1.39"
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 std = []
+serde = ["dep:serde"]
 
 [dependencies]
 # On compilers older than 1.65, features=["backtrace"] may be used to enable
@@ -22,12 +23,15 @@ std = []
 # preferred.
 backtrace = { version = "0.3.51", optional = true }
 
+serde = { version = "1" , optional = true }
+
 [dev-dependencies]
 futures = { version = "0.3", default-features = false }
 rustversion = "1.0.6"
 syn = { version = "2.0", features = ["full"] }
 thiserror = "2"
 trybuild = { version = "1.0.108", features = ["diff"] }
+serde_json = "1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,8 @@ mod macros;
 mod nightly;
 mod ptr;
 mod wrapper;
+#[cfg(feature = "serde")]
+mod serde;
 
 use crate::error::ErrorImpl;
 use crate::ptr::Own;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,20 @@
+use std::string::String;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Error;
+
+impl Serialize for Error {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use std::string::ToString;
+
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Error {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Error::msg(s))
+    }
+}

--- a/tests/test_fmt.rs
+++ b/tests/test_fmt.rs
@@ -91,3 +91,13 @@ fn test_altdebug() {
     assert_eq!(EXPECTED_ALTDEBUG_G, format!("{:#?}", g().unwrap_err()));
     assert_eq!(EXPECTED_ALTDEBUG_H, format!("{:#?}", h().unwrap_err()));
 }
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_serde() {
+    let error = f().unwrap_err();
+    let serialized = serde_json::to_string(&error).unwrap();
+    assert_eq!(serialized, "\"oh no!\"");
+    let deserialized: anyhow::Error = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.to_string(), "oh no!");
+}


### PR DESCRIPTION
This adds optional serde implementation for the error to serialize/deserialize the error.

This allows the user to pass around the error types across the communication boundaries in apps such as Tauri without needing to convert the types. That means the `?` operator can be used for Tauri commands, and any code that uses `anyhow:Error` can become a `tauri::command` without any modification.

https://tauri.app/develop/calling-rust/#error-handling

With this feature
```rs
#[tauri::command]
fn my_custom_command() -> Result<(), anyhow::Error> {
  std::fs::File::open("path/that/does/not/exist")?;
  Ok(())
}
```

Without this feature
```rs
#[tauri::command]
fn my_custom_command() -> Result<(), String> {
  std::fs::File::open("path/that/does/not/exist").map_err(|e| e.to_string)?;
  Ok(())
}
```

Fixes https://github.com/tauri-apps/tauri/discussions/4800