### PR TITLE
Use `.into()` on macros directly `return`-ing

### DIFF
--- a/src/ensure.rs
+++ b/src/ensure.rs
@@ -900,7 +900,7 @@ macro_rules! __fancy_ensure {
                             $crate::__private::stringify!($rhs),
                             "`",
                         ),
-                    ));
+                    ).into());
                 }
             }
         }
@@ -914,22 +914,22 @@ macro_rules! __fallback_ensure {
         if $crate::__private::not($cond) {
             return $crate::__private::Err($crate::Error::msg(
                 $crate::__private::concat!("Condition failed: `", $crate::__private::stringify!($cond), "`")
-            ));
+            ).into());
         }
     };
     ($cond:expr, $msg:literal $(,)?) => {
         if $crate::__private::not($cond) {
-            return $crate::__private::Err($crate::__anyhow!($msg));
+            return $crate::__private::Err($crate::__anyhow!($msg).into());
         }
     };
     ($cond:expr, $err:expr $(,)?) => {
         if $crate::__private::not($cond) {
-            return $crate::__private::Err($crate::__anyhow!($err));
+            return $crate::__private::Err($crate::__anyhow!($err).into());
         }
     };
     ($cond:expr, $fmt:expr, $($arg:tt)*) => {
         if $crate::__private::not($cond) {
-            return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*));
+            return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*).into());
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -57,13 +57,13 @@
 #[cfg_attr(not(anyhow_no_clippy_format_args), clippy::format_args)]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return $crate::__private::Err($crate::__anyhow!($msg))
+        return $crate::__private::Err($crate::__anyhow!($msg)).into()
     };
     ($err:expr $(,)?) => {
-        return $crate::__private::Err($crate::__anyhow!($err))
+        return $crate::__private::Err($crate::__anyhow!($err)).into()
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*))
+        return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*)).into()
     };
 }
 
@@ -131,22 +131,22 @@ __ensure![
             if !$cond {
                 return $crate::__private::Err($crate::Error::msg(
                     $crate::__private::concat!("Condition failed: `", $crate::__private::stringify!($cond), "`")
-                ));
+                )).into();
             }
         };
         ($cond:expr, $msg:literal $(,)?) => {
             if !$cond {
-                return $crate::__private::Err($crate::__anyhow!($msg));
+                return $crate::__private::Err($crate::__anyhow!($msg)).into();
             }
         };
         ($cond:expr, $err:expr $(,)?) => {
             if !$cond {
-                return $crate::__private::Err($crate::__anyhow!($err));
+                return $crate::__private::Err($crate::__anyhow!($err)).into();
             }
         };
         ($cond:expr, $fmt:expr, $($arg:tt)*) => {
             if !$cond {
-                return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*));
+                return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*)).into();
             }
         };
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -57,13 +57,13 @@
 #[cfg_attr(not(anyhow_no_clippy_format_args), clippy::format_args)]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return $crate::__private::Err($crate::__anyhow!($msg)).into()
+        return $crate::__private::Err($crate::__anyhow!($msg).into())
     };
     ($err:expr $(,)?) => {
-        return $crate::__private::Err($crate::__anyhow!($err)).into()
+        return $crate::__private::Err($crate::__anyhow!($err).into())
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*)).into()
+        return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*).into())
     };
 }
 
@@ -131,22 +131,22 @@ __ensure![
             if !$cond {
                 return $crate::__private::Err($crate::Error::msg(
                     $crate::__private::concat!("Condition failed: `", $crate::__private::stringify!($cond), "`")
-                )).into();
+                ).into());
             }
         };
         ($cond:expr, $msg:literal $(,)?) => {
             if !$cond {
-                return $crate::__private::Err($crate::__anyhow!($msg)).into();
+                return $crate::__private::Err($crate::__anyhow!($msg).into());
             }
         };
         ($cond:expr, $err:expr $(,)?) => {
             if !$cond {
-                return $crate::__private::Err($crate::__anyhow!($err)).into();
+                return $crate::__private::Err($crate::__anyhow!($err).into());
             }
         };
         ($cond:expr, $fmt:expr, $($arg:tt)*) => {
             if !$cond {
-                return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*)).into();
+                return $crate::__private::Err($crate::__anyhow!($fmt, $($arg)*).into());
             }
         };
     }


### PR DESCRIPTION
Hey!

Using .into() allows for compatibility with wrapper types, just like in axum, for example!
Someone please review as I don't really think I changed the documentation...

Thanks,
Alex <3