### PR TITLE
chore: improve anyhow maintenance path

### DIFF
--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -67,3 +67,23 @@ fn test_clone() {
     assert!(chain.next().is_none());
     assert!(chain.next_back().is_none());
 }
+
+#[test]
+fn test_deeply_nested() {
+    let e = anyhow!({ 0 })
+        .context(1)
+        .context(2)
+        .context(3)
+        .context(4)
+        .context(5);
+    let mut chain = e.chain();
+    assert_eq!(6, chain.len());
+    assert_eq!("5", chain.next().unwrap().to_string());
+    assert_eq!("4", chain.next().unwrap().to_string());
+    assert_eq!("0", chain.next_back().unwrap().to_string());
+    assert_eq!("3", chain.next().unwrap().to_string());
+    assert_eq!("1", chain.next_back().unwrap().to_string());
+    assert_eq!("2", chain.next().unwrap().to_string());
+    assert!(chain.next().is_none());
+    assert!(chain.next_back().is_none());
+}

--- a/tests/test_context.rs
+++ b/tests/test_context.rs
@@ -170,3 +170,24 @@ fn test_root_cause() {
 
     assert_eq!(err.root_cause().to_string(), "no such file or directory");
 }
+
+#[test]
+fn test_chain_order_and_downcast() {
+    let (err, dropped) = make_chain();
+
+    let mut chain = err.chain();
+    assert_eq!("failed to start server", chain.next().unwrap().to_string());
+    assert_eq!("failed to load config", chain.next().unwrap().to_string());
+    assert_eq!("no such file or directory", chain.next().unwrap().to_string());
+    assert!(chain.next().is_none());
+
+    assert!(err.downcast_ref::<LowLevel>().is_some());
+    assert_eq!(
+        err.downcast_ref::<LowLevel>().unwrap().to_string(),
+        "no such file or directory"
+    );
+
+    assert!(dropped.none());
+    drop(err);
+    assert!(dropped.all());
+}


### PR DESCRIPTION
Summary:
- Add edge-case unit tests for Error::chain() iterator behavior on deeply nested contexts and for context() applied to Result<T, E> where E already implements std::error::Error with a custom Display, verifying the chain order and that downcast_ref still finds the innermost source. Tests-only change, no behavior modification.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.